### PR TITLE
fix(core): refactor to work with Sails 1.0, OpenAPI 3, JSDoc (work in progress)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,8 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 
-This helps to create swagger documentation json which is based entirely on swagger specification [Specifications](https://swagger.io/specification/).
+This helps to create swagger documentation json which is based entirely on Swagger/OpenAPI specification (see [here](https://swagger.io/specification/)).
+The hook produces specification based upon OAS 3.0.
 
 ![](screenshot/swagger-doc.gif)
 
@@ -23,26 +24,47 @@ Just install the library and `sails lift`, the moment you do, that's all check y
 
 
 ## Example
-check the **./swagger/swagger.json** for sample generated swagger documentation json, then head to [Swagger Editor](http://editor.swagger.io/)
+Check the **./swagger/swagger.json** for sample generated swagger documentation json, then head to [Swagger Editor](http://editor.swagger.io/).
+
+## Generated Output
+
+By default, the Swagger Generator Sails Hook generates:
+1. Full automatic documentation for all Sails Blueprint routes;
+1. Documentation for all Sails
+   [actions2](https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2)
+   actions with routes configured in `config/routes.js`; and
+1. Listing of all routes configured in `config/routes.js` (full details cannot be inferred
+   for custom routes without additional information being provided - see below).
+
+## Adding/Customising Generated Output
+
+Documentation detail and customisation of most aspects of the generated Swagger can be achieved by:
+1. Top-level configuration to `config/swaggergenerator.js`. This provides direct JSON
+   used as the template for the output Swagger/OpenAPI.
+1. Adding objects with the key `swagger` to custom route configuration, controller files, action
+   functions, model definitions and model attribute definitions.
+1. Adding JSDoc ([swagger-jsdoc](https://github.com/Surnet/swagger-jsdoc)) `@swagger` comments to
+   `config/routes.js`, controller/action files and model files.
+
+Top-level Swagger/OpenAPI definitions for `tags` and `components` may be added in all `swagger` objects
+above and in all JSDoc `@swagger` documentation comments. This enables the definition of top-level elements
+in the location where they are logically defined/documented within the Sails application.
+
+All content added to `swagger` objects is merged into the generated output **except** those at the top-level with
+keys that use an `_` (underscore) prefix, which are processed specially
+e.g. `_tags`, `_components`, `_{actionName}` or `_{blueprintAction}`.
+
+See below for details.
 
 ## Configurations
-It comes with some default settings which can be override by creating **config/swaggergenerator.js**
+
+It comes with some default settings which can be overridden by creating `config/swaggergenerator.js`:
 ```javascript
-module.exports["swagger-generator"] = {
+module.exports['swagger-generator'] = {
     disabled: false,
-    swaggerJsonPath: "./swagger/swagger.json",
-    parameters: { //we can add up custom parameters here
-        PerPageQueryParam: {
-            in: 'query',
-            name: 'perPage',
-            required: false,
-            type: 'integer',
-            description: 'This helps with pagination and when the limit is known for pagify'
-        }
-    },
-    blueprint_parameters: {list: [{$ref: '#/parameters/PerPageQueryParam'}]},//we can add custom blueprint action to parameters binding here, any specified overrides default created
+    swaggerJsonPath: './swagger/swagger.json',
     swagger: {
-        swagger: '2.0',
+        openapi: '3.0.0',
         info: {
             title: 'Swagger Json',
             description: 'This is a generated swagger json for your sails project',
@@ -51,95 +73,68 @@ module.exports["swagger-generator"] = {
             license: {name: 'Apache 2.0', url: 'http://www.apache.org/licenses/LICENSE-2.0.html'},
             version: '1.0.0'
         },
-        host: 'localhost:1337',
-        basePath: '/',
+        servers: [
+            { url: 'http://localhost:1337/' }
+        ],
         externalDocs: {url: 'http://theophilus.ziippii.com'}
-    }
+    },
+    defaults: {
+        responses: {
+            '200': { description: 'The requested resource' },
+            '404': { description: 'Resource not found' },
+            '500': { description: 'Internal server error' }
+        }
+    },
+    includeRoute: function(routeInfo) { return true; },
+    updateBlueprintActionTemplates: function(blueprintActionTemplates) { ... },
+    postProcess: function(specifications) { ... }
 };
 ```
-* **disabled** attribute is used to disable the module. (e.g you may want to disable it on production)
-* **swaggerJsonPath** where to generate the `swagger.json` file to, default to `sails.config.appPath + "/swagger/swagger.json"`
-* **parameters** we can create your own custom parameter to be referenced by api service methods and it's totally based on swagger specification for parameter object. Any one added here is added to the default parameters which are
-```javascript
- //default parameters-> where, limit, skip, sort, populate, select, page
-    params.WhereQueryParam = {
-        in: 'query',
-        name: 'where',
-        required: false,
-        type: 'string',
-        description: 'This follows the standard from http://sailsjs.com/documentation/reference/blueprint-api/find-where'
-    };
-    params.LimitQueryParam = {
-        in: 'query',
-        name: 'limit',
-        required: false,
-        type: 'integer',
-        description: 'The maximum number of records to send back (useful for pagination). Defaults to ' + config.blueprints.defaultLimit
-    };
-    params.SkipQueryParam = {
-        in: 'query',
-        name: 'skip',
-        required: false,
-        type: 'integer',
-        description: 'The number of records to skip (useful for pagination).'
-    };
-    params.SortQueryParam = {
-        in: 'query',
-        name: 'sort',
-        required: false,
-        type: 'string',
-        description: 'The sort order. By default, returned records are sorted by primary key value in ascending order. e.g. ?sort=lastName%20ASC'
-    };
 
-    params.PopulateQueryParam = {
-        in: 'query',
-        name: 'populate',
-        required: false,
-        type: 'string',
-        description: 'check for better understanding -> http://sailsjs.com/documentation/reference/blueprint-api/find-where'
-    };
+Notes on the use of configuration:
 
-    params.PageQueryParam = {
-        in: 'query',
-        name: 'page',
-        required: false,
-        type: 'integer',
-        description: 'This helps with pagination and when the limit is known'
-    };
-    params.SelectQueryParam = {
-        in: 'query',
-        name: 'select',
-        required: false,
-        type: 'string',
-        description: 'This helps with what to return for the user and its "," delimited'
-    };
+* `disabled` attribute is used to disable the module (e.g you may want to disable it on production).
+* `swaggerJsonPath` where to generate the `swagger.json` file to; defaults to `sails.config.appPath + '/swagger/swagger.json'`.
+* `swagger` object is template for the Swagger/OpenAPI output. It defaults to the minimal content above.
+   Check Swagger/OpenAPI specification for more, in case you want to extend it.
+   Generally, this hook provides sensible defaults for as much as possible but you may
+   override them in this location or in any of the mechanisms explained below.
+* `defaults` object should contain the `responses` element; defaults to the above if not specified.
+* `includeRoute` function used to filter routes to be included in generated Swagger output; see advanced section below.
+* `updateBlueprintActionTemplates` allows customisation of the templates used to generate Swagger for blueprints; see advanced section below.
+* `postProcess` allows modification of the generated Swagger output before it is written to the output file; see advanced section below.
 
-    params.TokenHeaderParam = {
-        in: 'header',
-        name: 'token',
-        required: false,
-        type: 'string',
-        description: 'Incase we want to send header inforamtion along our request'
-    };
-
-    params.IDPathParam = {
-        in: 'path',
-        name: 'id',
-        required: true,
-        type: 'string',
-        description: 'This is to identify a particular object out'
-    };
-```
-* **blueprint_parameters** is a map between blueprint action and list of parameters and it's based on referencing of a particular parameter which can be any of this *WhereQueryParam*, *LimitQueryParam*, *SkipQueryParam*, *SortQueryParam*, *PopulateQueryParam*, *PageQueryParam*, *SelectQueryParam*, *TokenHeaderParam*, *IDPathParam* and the ones created under the **parameters** above. Any array of parameter mapped to a blueprint action overrides the default mapped parameters.
-* **Swagger** object is used to hold necessary information needed by swagger to run our mock test of api services. Check swagger specification for more, incase you want to extend it.
 
 ## Custom Route Configuration
-If you want to add extra configuration to a route, it can be done via the `config/routes.js`, since sails uses any of this two route pattern
-* `'http_method route':'controller.action'` or
-* `'http_method route':{controller:'controller', action:'action'}`
 
-We can extend and add extra information on the second above for sails hook swagger generator to override default properties(which is created from the first). Adding an object with a key **swagger** will do the trick.
+Documentation detail and customisation of most aspects of the generated Swagger for
+[custom routes](https://sailsjs.com/documentation/concepts/routes/custom-routes) may be achieved by:
 
+1. Adding an object with the key `swagger` to individual route configurations in `config/routes.js`.
+1. Adding an object with the key `swagger` added to a controller file action function.
+1. Adding an object with the key `swagger` to the exports of a controller file, standalone action file or actions2 file.
+1. Adding JSDoc `@swagger` comments to route configurations in `config/routes.js`; specifically:
+  - JSDoc `@swagger` documentation under the `/{routePath}` and `{httpMethod}` *Swagger path* for routes, or
+  - JSDoc `@swagger` documentation under `tags` and `components` paths for adding to the top-level Swagger/OpenAPI definitions.
+1. Adding JSDoc `@swagger` comments to Sails
+  [controller files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?controllers),
+  [standalone action files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?standalone-actions) or
+  [actions2 files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2); specifically:
+  - JSDoc `@swagger` documentation under the `/{actionName}` path for the route, or
+  - JSDoc `@swagger` documentation under `tags` and `components` paths for adding to the top-level Swagger/OpenAPI definitions.
+
+### Custom Route Configuration in `config/routes.js`
+
+If you want to add extra configuration to a route, it can be done via the `config/routes.js`, since Sails uses any of these two route patterns
+(see full documentation [here](https://sailsjs.com/documentation/concepts/routes/custom-routes#?route-address)):
+* `'http_method route': 'controller.action'` or
+* `'http_method route': { controller:'controller', action:'action' }`
+
+We can extend and add extra information on the second above for sails hook swagger generator to override
+default properties (which is created from the first). Adding an object with a key `swagger` or adding
+JSDoc `@swagger` commonents will do the trick.
+
+For example, in `config/routes.js`:
 ```javascript
 {
   'post /user/login': {
@@ -148,34 +143,473 @@ We can extend and add extra information on the second above for sails hook swagg
     swagger: {
       summary: 'Authentication',
       description: 'This is for authentication of any user',
-      body: {
-        username: { type: 'string', required: true },
-        password: { type: 'password', required: true }
+      tags: [ 'Tag Name' ],
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              properties: {
+                email: { type: 'string' },
+                password: { type: 'string', format: 'password' }
+              },
+              required: [ 'email', 'password' ],
+            }
+          }
+        }
       },
-      query: [{
-        $ref: '#/parameters/IDPathParam'
-      }],
       parameters: [{
         in: 'query',
         name: 'firstName',
         required: true,
-        type: 'string',
+        schema: { type: 'string' },
         description: 'This is a custom required parameter'
-      }]
+      }],
+      responses: {
+        '200': {
+          description: 'The requested resource',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { '$ref': '#/components/schemas/someDataType' },
+                },
+              },
+            },
+        },
+        '404': { description: 'Resource not found' },
+        '500': { description: 'Internal server error' }
+      }
     }
   }
 }
 ```
 
-### Properties of swagger
-* **summary**: for adding your own custom summary, e.g Authentication
-* **description**: for giving detailed description about the api service method, e.g This is for authentication of any type of user
-* **body**: if the route is taking in form post, and it follows our normal attribute from [sails model](http://sailsjs.com/documentation/concepts/models-and-orm/attributes)
-* **query**: for any query you expecting from the user consuming the service method, you can also reference the default created above (*WhereQueryParam*, *LimitQueryParam*, *SkipQueryParam*, *SortQueryParam*, *PopulateQueryParam*, *PageQueryParam*, *SelectQueryParam*, *TokenHeaderParam*, *IDPathParam*) and add your own following the swagger specification.
-* We can also add custom personalized **parameters** if required.
+Alternately, JSDoc `@swagger` comments may be added for route configuration in `config/routes.js` as follows:
+1. JSDoc `@swagger` documentation under the `/{routePath}` and `{httpMethod}` *Swagger path* for routes, or
+1. JSDoc `@swagger` documentation under `tags` and `components` paths for adding to the top-level Swagger/OpenAPI definitions.
 
-**NB** it overrides the default route params attached from the sails generator
+For example, in `config/routes.js`:
+```javascript
+{
+  /** @swagger
+   * /clients/:client_id/user/:id:
+   *   delete:
+   *     summary: Client Op
+   *     description: This is not really useful - example only :)
+   */
+  'delete /clients/:client_id/user/:id': 'UserController.destroy',
+}
+```
 
+### Custom Route Configuration in Controller or Action files
+
+Documentation detail and customisation of most aspects of the generated Swagger may be added to
+[controller files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?controllers),
+[standalone action files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?standalone-actions) or
+[actions2 files](https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2) as follows:
+
+1. Adding an object with the key `swagger` added to a controller file action function.
+1. Adding an object with the key `swagger` to the exports of a controller file, standalone action file or actions2 file:
+   - For controller files, actions are referenced by adding objects keyed on `_{actionName}` name.
+   - For standalone action or actions2 files, placing content in the `swagger` object itself.
+   - Adding documentation under `_tags` and `_components` elements for adding to the top-level Swagger/OpenAPI definitions.
+1. Adding JSDoc `@swagger` comments to controller file, standalone action file or actions2 file:
+   - JSDoc `@swagger` documentation under the `/{actionName}` path for the route, or
+   - JSDoc `@swagger` documentation under `tags` and `components` paths for adding to the top-level Swagger/OpenAPI definitions.
+
+Note the use of the `_` (underscore) prefix to avoid clashes with / distinguish them from general Swagger/OpenAPI elements.
+
+For actions2 files:
+1. Inputs are parsed to generate parameter documentation.
+2. Exits are parsed to generate response documentation.
+3. Both may be customised/overridden by specifying parameters and/or responses in the `swagger` object
+   in actions2 file.
+
+For example, for a route configured as:
+```javascript
+module.exports.routes = {
+    '/api/v1/auth/tokens': 'AuthController.tokens',
+};
+```
+
+The `tokens` action might be documented in a Controller `api/controllers/AuthController.js` as follows:
+```javascript
+function tokens(req, res) {
+    ...
+}
+
+module.exports = {
+    tokens: tokens,
+    swagger: {
+        _tokens: {
+            tags: [ 'Auth' ],
+            description: 'Route description...'
+        },
+        _tags: [
+            {
+                name: 'Auth',
+                description: 'Module description ...',
+            }
+        ],
+    }
+};
+```
+
+Or, alternately:
+```javascript
+function tokens(req, res) {
+    ...
+}
+
+tokens.swagger = {
+    tags: [ 'Auth ],
+    description: 'Route description...'
+}
+
+module.exports = {
+    tokens: tokens,
+    swagger: {
+        _tags: [ ... ]
+    }
+};
+```
+
+Or, alternately using JSDoc:
+```javascript
+/**
+ * @swagger
+ *
+ * /tokens:
+ *   description: Route description...
+ *   tags:
+ *     - Auth
+ * tags:
+ *   - name: Auth
+ *     description: Module description...
+ */
+function tokens(req, res) {
+    ...
+}
+
+module.exports = {
+    tokens: tokens
+};
+```
+
+## Blueprint Route Configuration
+
+Documentation detail and customisation of most aspects of the generated Swagger for
+[blueprint routes](https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes) may be achieved by:
+
+1. Adding an object with the key `swagger` to individual models e.g. `api/models/modelName.js`:
+   - Documenting the Swagger **schema** associated with the Sails mode by adding general content.
+   - Adding per-action documentation by adding objects keyed on `_{blueprintAction}` name.
+   - Adding documentation under `_tags` and `_components` elements for adding to the top-level Swagger/OpenAPI definitions.
+1. Adding specific fields to model attributes (supports `description`, `externalDocs` and `example`).
+   Note that applicable Sails [attributes](https://sailsjs.com/documentation/concepts/models-and-orm/attributes),
+   [automigrations](https://sailsjs.com/documentation/concepts/models-and-orm/attributes#?automigrations) and
+   [validations](https://sailsjs.com/documentation/concepts/models-and-orm/validations) are also parsed.
+1. JSDoc `@swagger` documentation under the `/{globalId}` path for models.
+1. JSDoc `@swagger` per-action documentation under the `/{blueprintAction}` path for the
+  [model blueprint actions](https://sailsjs.com/documentation/concepts/blueprints/blueprint-actions).
+1. JSDoc `@swagger` documentation under `tags` and `components` paths for adding to the top-level Swagger definitions.
+
+Note the use of the `_` (underscore) prefix to avoid clashes with / distinguish them from general Swagger/OpenAPI elements.
+
+For example, in a model `api/models/User.js`:
+
+```javascript
+/**
+ * @swagger
+ *
+ * /User:
+ *   tags:
+ *     - Tag Name
+ * /findone:
+ *   externalDocs:
+ *     url: https://docs.com/here
+ */
+module.exports = {
+  attributes: {
+    uid: {
+      type: 'string',
+      example: '012345',
+      description: 'A unique identifier',
+    }
+  },
+  swagger: {
+    _create: { ... },
+    _tags: { ... }
+  }
+};
+```
+
+Note that following parameters are added to the `components/parameters` if they are not
+provided in `config/swaggergenerator.js` (expressed as OpenAPI references):
+
+```javascript
+[
+  { $ref: '#/components/parameters/WhereQueryParam' },
+  { $ref: '#/components/parameters/LimitQueryParam' },
+  { $ref: '#/components/parameters/SkipQueryParam' },
+  { $ref: '#/components/parameters/SortQueryParam' },
+  { $ref: '#/components/parameters/SelectQueryParam' },
+  { $ref: '#/components/parameters/PopulateQueryParam' },
+]
+```
+
+Note that when generating Swagger/OpenAPI documentation for blueprint routes, the hook also
+generates:
+
+1. Schemas for **models**, which may be referenced using the form `{ $ref: '#/components/schemas/modelName' }`.
+2. Parameters for model **primary keys**, which may be referenced using the form `{ $ref: '#/components/parameters/ModelPKParam-modelName' }`.
+
+These may be re-used (referenced) if/as applicable within custom route documentation.
+
+
+## Handling Top-Level Swagger Defintions (Tags and Components)
+
+You are able to add to the top-level Swagger/OpenAPI definitions for `tags` and `components` in all `swagger` objects
+detailed above and in all JSDoc `@swagger` documention comments.
+
+All `swagger` objects may contain the elements `_tags` and `_components` e.g.
+
+```javascript
+{
+  _tags: [
+    {
+      name: 'Test Module',
+      description: 'Module description ...',
+      externalDocs: { url: 'https://docs.com/test' }
+    }
+  ],
+  _components: {
+    schemas: {
+      test: { ... }
+    }
+  }
+}
+```
+
+Note the use of the `_` (underscore) prefix to avoid clashes with / distinguish them from general Swagger/OpenAPI elements.
+
+Similarly, JSDoc `@swagger` tags may define `tags` and `components`:
+
+```javascript
+/**
+ * @swagger
+ *
+ * tags:
+ *   - name: Test Module
+ *     description: |
+ *       Module description
+ *       (continued).
+ *
+ *       Another paragraph.
+ *
+ *     externalDocs:
+ *       url: https://docs.com/test
+ *       description: Refer to these docs
+ *
+ * components:
+ *   schemas:
+ *     test:
+ *       ...
+ */
+```
+
+### Tags Handling
+
+Tags are added to the top-level Swagger/OpenAPI definitions as follows:
+1. If a tags with the specified name **does not** exist, it is added.
+1. Where a tag with the specified name **does** exist, elements _of that tag_ that do not exist are added
+   e.g. `description` and `externalDocs` elements.
+
+### Component Element Handling
+
+Elements of components are added to the top-level Swagger/OpenAPI definitions as follows:
+1. Elements of the component definition reference (schemas, parameters, etc) are added where
+   they **do not exist**.
+1. Existing elements are **not** overwritten or merged.
+
+The following elements (from the OpenAPI 3 specification) are handled:
+```javascript
+let componentDefinitionReference = {
+    // Reusable schemas (data models)
+    schemas: {},
+    // Reusable path, query, header and cookie parameters
+    parameters: {},
+    // Security scheme definitions (see Authentication)
+    securitySchemes: {},
+    // Reusable request bodies
+    requestBodies: {},
+    // Reusable responses, such as 401 Unauthorized or 400 Bad Request
+    responses: {},
+    // Reusable response headers
+    headers: {},
+    // Reusable examples
+    examples: {},
+    // Reusable links
+    links: {},
+    // Reusable callbacks
+    callbacks: {},
+};
+```
+
+
+## Advanced Filtering/Processing of Generated Swagger
+
+Three mechanisms are provided to enable advancing filtering of the Swagger generation process:
+1. An `includeRoute()` function used to filter routes to be included in generated Swagger output.
+1. An `updateBlueprintActionTemplates()` function allows customisation of the templates used to generate Swagger for blueprints.
+1. A `postProcess()` function allows modification of the generated Swagger output before it is written to the output file.
+
+Each is configured in `config/swaggergenerator.js`.
+
+### Route Information
+
+This hook parses all routes, custom and blueprint, before commencing the generation of the Swagger output.
+Each route is described by a `RouteInfo` object
+(see defintions [here](lib/parsers.js#L211) and [here](lib/parsers.js#L350)):
+
+```javascript
+let routeInfo = {
+  middlewareType: string, // one of action|blueprint|view
+  blueprintAction: string, // optional; one of findone|find|create|update|destroy|populate|add|remove|replace or custom
+  httpMethod: string, // one of all|get|post|put|patch|delete
+  path: string, // full Sails URL as per sails.getUrlFor() including prefix
+  swaggerPath: string, // full Sails URL with ':token' replaced with '{token}' for use with Swagger
+  identity: string, // optional (present for blueprints only); Sails Model identity
+  modelInfo: object, // optional (present for blueprints only); Sails Model metadata
+  controller: string, // Sails Controller relative path including 'Controller' suffix
+  tags: string[], // default name of Swagger group based on Sails controller/action or Sails Model globalId
+  actionPath: string, // Sails Controller action path consistent with 'router:bind' events (controller relative path without suffix + action name)
+  actionName: string, // Sails Controller action name e.g. findone or buildModels
+  actionType: string, // one of controller|standalone|actions2
+  actionFound: string, // one of notfound|loaded+notfound|loaded+found|implicit
+  actions2: object, // optional; present for custom routes with actions2 actions
+  patternVariables: string[], // route dynamic parameters
+  associations: object[], // optional (present for blueprints only); Sails Model associations
+  aliases: string[], // optional (applicable for populate blueprints only); Sails Model attribute names for populate action(s)
+  associationsPrimaryKeyAttributeInfo: object[], // optional (present for blueprints only); array of attributeInfo's for association PKs
+  swagger: object, // per-route swagger (see below)
+};
+```
+
+Sails **models** are described by a `ModelInfo` object
+(see defintion [here](lib/parsers.js#L62)):
+
+```javascript
+let modelInfo = {
+  tags: string[], // default name of Swagger group based on model globalId
+  globalId: string, // model globalId
+  identity: string, // model identity
+  primaryKey: string, // name of primary key attribute
+  attributes: object, // attribute definition as per Sails model definition
+  swagger: object, // model-specific swagger (see below)
+};
+```
+
+### Route Filtering
+
+The `includeRoute(routeInfo): boolean` function may be used to select which routes are included in the generated Swagger output.
+
+For example:
+```javascript
+module.exports['swagger-generator'] = {
+  includeRoute: (routeInfo) => {
+    let c = routeInfo.controller;
+    if(!c) return true;
+    if(c.toLowerCase().startsWith('user')) return true;
+    return false;
+  }
+}
+```
+
+### Customising Blueprint Action Templates
+
+The templates used for generating Swagger for each Sails blueprint action route may be
+customised / modified / added to using the `updateBlueprintActionTemplates` config option
+e.g. to support custom blueprint actions/routes.
+
+For example:
+```javascript
+module.exports['swagger-generator'] = {
+  updateBlueprintActionTemplates: function(blueprintActionTemplates) {
+    blueprintActionTemplates.search = { ... };
+  }
+}
+```
+
+The `blueprintActionTemplates` object contains keys of the blueprint **action names**
+and values as per the following example (refer to the
+[source code](lib/type-formatter.js#L70) for the default templates):
+
+```javascript
+let blueprintActionTemplates = {
+  findone: {
+    summary: 'Get {globalId} (find one)',
+    description: 'Look up the **{globalId}** record with the specified ID.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/find-one',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/find-one'
+    },
+    parameters: [
+      'primaryKeyPathParameter', // special case; filtered and substituted during generation phase
+      { $ref: '#/components/parameters/LimitQueryParam' },
+    ],
+    resultDescription: 'Responds with a single **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Response denoting **{globalId}** record with specified ID **NOT** found',
+    // if functions, each called with (blueprintActionTemplate, routeInfo, pathEntry)
+    modifiers: ['addSelectQueryParam', exampleModifierFunctionRef],
+  },
+  ...
+};
+```
+
+Note that:
+1. For summary and description strings the value `{globalId}` is replaced with the applicable Sails model value.
+1. Parameters values are Swagger definitions, with the exception of the *special* string value
+   `primaryKeyPathParameter`, which may be used to include a reference to a model's primary key.
+1. Modifiers are used to apply custom changes to the generated Swagger, noting that:
+   - String values are predefined in `generatePaths()` (refer to the [source code](lib/generators.js#L246));
+     valid  modifiers are:
+     - `addPopulateQueryParam`
+     - `addSelectQueryParam`
+     - `addOmitQueryParam`
+     - `addModelBodyParam`
+     - `addResultOfArrayOfModels`
+     - `addAssociationPathParam`
+     - `addAssociationFKPathParam`
+     - `addAssociationResultOfArray`
+     - `addResultOfModel`
+     - `addResultNotFound`
+     - `addResultValidationError`
+     - `addFksBodyParam`
+   - Functions are called as `func(blueprintActionTemplate, routeInfo, pathEntry, tags, components)`
+     where
+     - `blueprintActionTemplate` the blueprint action template (see above) to which the modifier relates
+     - `routeInfo` the route information object (see above) for which the Swagger is being generated
+     - `pathEntry` the generated Swagger path entry to be modified
+     - `tags` the generated Swagger **tag** definitions to be modified/extended
+     - `components` the generated Swagger **component** definitions to be modified/extended
+
+### Post-processing Generated Swagger Output
+
+The final generated Swagger output may be post-processed before it is written to
+the output file using a post-processing function specified as the `postProcess` config option.
+
+For example:
+```javascript
+module.exports['swagger-generator'] = {
+  postProcess: function(specifications) {
+    let sch = specifications.components.schemas;
+    Object.keys(sch).map(k => {
+      sch[k].description = sck[k].description.toUpperCase();
+    });
+  }
+}
+```
 
 
 ## Testing
@@ -194,6 +628,7 @@ $ npm test
 ```
 
 ## Road Map
+
 Since the release of v1.0.0 of [sailsjs](https://github.com/balderdashy/sails)
 * [x] test compatibility with v1.0.0
 * [ ] read info about a controller using machine-as-action [#4](https://github.com/theo4u/sails-hook-swagger-generator/issues/4)

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -5,24 +5,83 @@
  * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
  */
 
+/**
+ * @swagger
+ * tags:
+ *   name: Auth Mgt
+ *   description: User management and login
+ */
+
+function list2(req, res) {
+
+}
+
+list2.swagger = {
+  tags: [ 'User List' ],
+  description: 'Return a user list (alternate)'
+}
+
 module.exports = {
-    login: function (req, res) {
 
+  login: function (req, res) {
+
+  },
+
+  /**
+   * @swagger
+   *
+   * /logout:
+   *   summary: Perform Logout
+   *   description: Logout of the application
+   *   tags:
+   *     - Auth Mgt
+   *   parameters:
+   *     - name: example-only
+   *       description: Username to use for logout (dummy for test)
+   *       in: path
+   *       required: true
+   *       schema:
+   *         type: string
+   *     - name: password
+   *       description: User's password (dummy for test)
+   *       in: query
+   *       required: true
+   *       schema:
+   *         type: string
+   *   responses:
+   *     200:
+   *       description: logout result
+   */
+  logout: function (req, res) {
+
+  },
+
+  upload: function (req, res) {
+
+  },
+
+  list: function (req, res) {
+
+  },
+
+  list2: list2,
+
+  roles: function (req, res) {
+
+  },
+
+  swagger: {
+    _list: {
+      tags: ['User List'],
+      description: 'Return a user list'
     },
-    logout: function (req, res) {
+    _tags: [
+      {
+        name: 'User List',
+        description: 'Group just for user list operation',
+      }
+    ],
+  },
 
-    },
-
-    upload: function (req, res) {
-
-    },
-
-    list: function (req, res) {
-
-    },
-
-  roles: function (req, res)  {
-
-  }
 };
 

--- a/api/controllers/subdir/actions2.js
+++ b/api/controllers/subdir/actions2.js
@@ -1,0 +1,52 @@
+module.exports = {
+
+  friendlyName: 'Friendly',
+
+  description: 'Friendly description',
+
+  inputs: {
+    userId: {
+      description: 'The ID of the user to look up.',
+      type: 'number',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+    },
+    notFound: {
+      description: 'No user with the specified ID was found in the database',
+      responseType: 'notFound',
+      statusCode: 404,
+    }
+  },
+
+  swagger: {
+    tags: [ 'Actions2 Group' ],
+    responses: {
+      '200': {
+        content: {
+          'application/json': {
+            schema: { type: 'number', default: 123, },
+          },
+        },
+      }
+    },
+    _tags: [
+      {
+        name: 'Actions2 Group',
+        description: 'A test actions2 group',
+      },
+    ],
+  },
+
+  fn: async function ({userId}) {
+
+    return {
+      message: 'TEST ACTIONS2 (foobar) ' + userId,
+    };
+
+  }
+
+};

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -5,27 +5,78 @@
  * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
  */
 
+/**
+* @swagger
+*
+* /User:
+*   tags:
+*     - User (ORM)
+*     - User (ORM duplicate)
+*
+* /find:
+*   description: >
+*     _Alternate description_: Find a list of **User** records that match the specified criteria.
+*
+* tags:
+*
+*   - name: User (ORM)
+*     description: |
+*       A longer, multi-paragraph description
+*       explaining how this all works.
+*
+*       It is linked to more information.
+*
+*     externalDocs:
+*       url: https://somewhere.com/yep
+*       description: Refer to these docs
+*/
+
 module.exports = {
 
-    attributes: {
-        names: {
-            type: 'string',
-            required: true
-        },
-        email: {
-            type: 'string',
-            email: true
-        },
-        sex: {
-            type: 'string',
-            enum: ["Male", "Female"]
-        },
-        ageLimit: {
-            type: 'integer',
-            min: 15,
-            max: 100
-        }
-
+  attributes: {
+    id: {
+      type: 'number',
+      autoIncrement: true,
+    },
+    names: {
+      type: 'string',
+      required: true,
+      example: 'First Middle Last'
+    },
+    email: {
+      type: 'string',
+      email: true,
+      description: 'Just any old email',
+    },
+    sex: {
+      type: 'string',
+      enum: ['Male', 'Female']
+    },
+    ageLimit: {
+      type: 'number',
+      min: 15,
+      max: 100
     }
+
+  },
+
+  swagger: {
+
+    _findone: {
+      description: '_Alternate description_: Look up the **User** record with the specified ID.'
+    },
+
+    _tags: [
+      {
+        name: 'User (ORM duplicate)',
+        externalDocs: {
+          url: 'https://somewhere.com/alternate',
+          description: 'Refer to these alternate docs'
+        }
+      }
+    ],
+
+  }
+
 };
 

--- a/config/cors.js
+++ b/config/cors.js
@@ -26,7 +26,9 @@
  *
  */
 
-module.exports.cors = {
+module.exports.security = {};
+
+module.exports.security.cors = {
 
   /***************************************************************************
    *                                                                          *
@@ -47,7 +49,7 @@ module.exports.cors = {
    *                                                                          *
    ***************************************************************************/
 
-  origin: '*',
+  allowOrigins: '*',
 
   /***************************************************************************
    *                                                                          *
@@ -55,7 +57,7 @@ module.exports.cors = {
    *                                                                          *
    ***************************************************************************/
 
-  credentials: true,
+  allowCredentials: false,
 
   /***************************************************************************
    *                                                                          *
@@ -64,7 +66,7 @@ module.exports.cors = {
    *                                                                          *
    ***************************************************************************/
 
-  methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
+  allowRequestMethods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
 
   /***************************************************************************
    *                                                                          *
@@ -73,6 +75,6 @@ module.exports.cors = {
    *                                                                          *
    ***************************************************************************/
 
-  headers: 'content-type, Authorization'
+  allowRequestHeaders: 'content-type, Authorization'
 
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -22,77 +22,128 @@
 
 module.exports.routes = {
 
-    /***************************************************************************
-     *                                                                          *
-     * Make the view located at `views/homepage.ejs` (or `views/homepage.jade`, *
-     * etc. depending on your default view engine) your home page.              *
-     *                                                                          *
-     * (Alternatively, remove this and add an `index.html` file in your         *
-     * `assets` directory)                                                      *
-     *                                                                          *
-     ***************************************************************************/
+  /***************************************************************************
+   *                                                                          *
+   * Make the view located at `views/homepage.ejs` (or `views/homepage.jade`, *
+   * etc. depending on your default view engine) your home page.              *
+   *                                                                          *
+   * (Alternatively, remove this and add an `index.html` file in your         *
+   * `assets` directory)                                                      *
+   *                                                                          *
+   ***************************************************************************/
 
-    //not needed for now since no asset just api
-    // '/': {
-    //   view: 'homepage'
-    // },
+  //not needed for now since no asset just api
+  // '/': {
+  //   view: 'homepage'
+  // },
 
-    /***************************************************************************
-     *                                                                          *
-     * Custom routes here...                                                    *
-     *                                                                          *
-     * If a request to a URL doesn't match any of the custom routes above, it   *
-     * is matched against Sails route blueprints. See `config/blueprints.js`    *
-     * for configuration options and examples.                                  *
-     *                                                                          *
-     ***************************************************************************/
+  /***************************************************************************
+   *                                                                          *
+   * Custom routes here...                                                    *
+   *                                                                          *
+   * If a request to a URL doesn't match any of the custom routes above, it   *
+   * is matched against Sails route blueprints. See `config/blueprints.js`    *
+   * for configuration options and examples.                                  *
+   *                                                                          *
+   ***************************************************************************/
+
+  /** @swagger
+   * /clients/:client_id/user/:id:
+   *   delete:
+   *     summary: Client Op
+   *     description: This is not really useful - example only :)
+   */
   'delete /clients/:client_id/user/:id': 'UserController.destroy',
+
   'post /user': {
     controller: 'UserController',
     action: 'create',
+  },
+
+  'post /user/login': {
+    controller: 'UserController',
+    action: 'login',
     swagger: {
-      body: {
-        newVar: {type: 'string', required: true}
+      summary: 'Authentication',
+      description: 'This is for authentication of any user',
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              properties: {
+                email: { type: 'string' },
+                password: { type: 'string', format: 'password' }
+              },
+              required: [ 'email', 'password' ],
+            },
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Success' },
       }
     }
   },
-    'post /user/login': {
-        controller: 'UserController',
-        action: 'login',
-        swagger: {
-            summary: 'Authentication',
-            description: 'this is used to authenticate user to our api using either phoneNumber or email and password',
-            body: {
-                email: {type: 'string', required: true},
-                password: {type: 'password', required: true}
-            }
-        }
-    },
-    'get /user/logout': 'UserController.logout',
-    'get /user/test/:phoneNumber': 'UserController.logout',
-    'get /user/upload': {
-        controller: 'UserController',
-        action: 'upload',
-        swagger: {
-            body: {}, //for post and put
-            query: [] //for get and others
-        }
-    },
-    'put /user/roles': {
-        controller: 'UserController',
-        action: 'roles',
-        swagger: {
-            summary: 'update user roles',
-            body: {
-              roles: {
-                type: 'array',
-                required: true,
-                items: {
-                  type: 'string'
-                }
-              }
-            }
-        }
+
+  'get /user/logout': 'UserController.logout',
+  'get /user/list': 'UserController.list',
+  'get /user/list2': 'UserController.list2',
+
+  'get /actions2': 'subdir/actions2',
+
+  // 'get /user/test/:phoneNumber': 'UserController.logout',
+
+  'get /user/test/:phoneNumber': {
+    action: 'user/logout',
+    swagger: {
+      summary: 'Phone No. Logout',
+      description: 'Alternate description (of no real significance)'
     }
+  },
+
+  'get /user/upload': {
+    controller: 'UserController',
+    action: 'upload',
+    swagger: {
+      parameters: [{
+        in: 'query',
+        name: 'data',
+        required: true,
+        schema: {
+          type: 'string',
+        },
+        description: 'The data',
+      }],
+      responses: {
+        '200': { description: 'Success' },
+      }
+    }
+  },
+
+  'put /user/roles': {
+    controller: 'UserController',
+    action: 'roles',
+    swagger: {
+      summary: 'update user roles',
+      requestBody: {
+        content: {
+          'application/json': {
+            schema: {
+              properties: {
+                roles: {
+                  type: 'array',
+                  items: { type: 'string' }
+                }
+              },
+              required: [ 'roles' ]
+            }
+          },
+        },
+      },
+      responses: {
+        '200': { description: 'Success' },
+      }
+    }
+  }
 
 };

--- a/index.js
+++ b/index.js
@@ -1,52 +1,58 @@
 /**
  * Our hook
  */
+
+const _path = require('path');
+
 var swaggerDoc = require("./lib/swaggerDoc");
 
 module.exports = function (sails) {
-    return {
 
-        defaults: {
-            disabled: false,
-            __configKey__: {
-                swaggerJsonPath: sails.config.appPath + "/swagger/swagger.json",
-                parameters: { //we can add up custom parameters here
-                    PerPageQueryParam: {
-                        in: 'query',
-                        name: 'perPage',
-                        required: false,
-                        type: 'integer',
-                        description: 'This helps with pagination and when the limit is known for pagify'
-                    }
-                },
-                blueprint_parameters: {list: [{$ref: '#/parameters/PerPageQueryParam'}]},//we can add custom blueprint action to parameters binding here, any specified overrides default created
-                swagger: {
-                    swagger: '2.0',
-                    info: {
-                        title: 'Swagger Json',
-                        description: 'This is a generated swagger json for your sails project',
-                        termsOfService: 'http://example.com/terms',
-                        contact: {
-                            name: 'Theophilus Omoregbee',
-                            url: 'http://github.com/theo4u',
-                            email: 'theo4u@ymail.com'
-                        },
-                        license: {name: 'Apache 2.0', url: 'http://www.apache.org/licenses/LICENSE-2.0.html'},
-                        version: '1.0.0'
-                    },
-                    host: 'localhost:1337',
-                    basePath: '/',
-                    externalDocs: {url: 'http://theophilus.ziippii.com'}
-                }
-            }
-        },
-        // Run when sails loads-- be sure and call `next()`.
-        initialize: function (next) {
-          sails.after('ready', () => {
-            swaggerDoc(sails, this);
-          });
-          next();
+  let routes = [];
+
+  return {
+
+    // capture the bound Sails routes
+    _routes: routes,
+
+    defaults: {
+      disabled: false,
+      __configKey__: {
+        swaggerJsonPath: _path.join(sails.config.appPath, '/swagger/swagger.json'),
+        swagger: {
+          openapi: '3.0.0',
+          info: {
+            title: 'Swagger Json',
+            description: 'This is a generated swagger json for your sails project',
+            termsOfService: 'http://example.com/terms',
+            contact: {
+              name: 'Theophilus Omoregbee',
+              url: 'http://github.com/theo4u',
+              email: 'theo4u@ymail.com'
+            },
+            license: { name: 'Apache 2.0', url: 'http://www.apache.org/licenses/LICENSE-2.0.html' },
+            version: '1.0.0'
+          },
+          servers: [
+            { url: 'http://localhost:1337/' }
+          ],
+          externalDocs: { url: 'http://theophilus.ziippii.com' }
         }
+      }
+    },
+    // Run when sails loads-- be sure and call `next()`.
+    initialize: function (next) {
 
-    };
+      // https://github.com/balderdashy/sails/blob/master/lib/EVENTS.md#routerbind
+      sails.on('router:bind', (routeObj) => {
+        routes.push(routeObj);
+      });
+
+      sails.after('ready', () => {
+        swaggerDoc(sails, routes, this);
+      });
+      next();
+    }
+
+  };
 };

--- a/index.js
+++ b/index.js
@@ -42,8 +42,10 @@ module.exports = function (sails) {
         },
         // Run when sails loads-- be sure and call `next()`.
         initialize: function (next) {
+          sails.after('ready', () => {
             swaggerDoc(sails, this);
-            return next();
+          });
+          next();
         }
 
     };

--- a/lib/generators.js
+++ b/lib/generators.js
@@ -1,439 +1,573 @@
 /**
  * Created by theophy on 02/08/2017.
  *
- * this is used to generate our tags from our sails
+ * this is used to generate our tags and paths from our sails
  */
 
-var _ = require("lodash");
-var parsers = require("./parsers");
-var formatter = require("./type-formatter");
+const _ = require('lodash');
+const formatters = require('./type-formatter');
 
 /**
- * this is used to parse models to tags just the globalId is picked to gather our
- * tags
- * @param models
- * @returns {Array}
- * @private
- */
-function _generateModels(models) {
-    var tags = [];
-
-    _.forEach(models, function (model) {
-
-        // Do tagging for  all models. Ignoring associative tables
-        if (model.globalId) {
-            tags.push({name: model.globalId, identity: model.identity});
-        }
-    });
-
-    return tags;
-}
-
-/**
- * this generates our definitions from our models and returns the equivalent swagger specification
- * @param models
- * @returns {{}}
- * @private
- */
-function _generateDefinitions(models) {
-    var defintions = {};
-
-    _.forEach(models, function (model) {
-        // Do tagging for  all models. Ignoring associative tables
-        if (model.globalId) {
-            defintions[model.identity] = parsers.attributes(model.attributes);
-        }
-    });
-
-
-    return defintions;
-}
-
-/**
- * this is used to generate our default parameters and extending the ones created in our
- * sails.config[configKey].parameters to the default
- * @param config
- * @param context
- * @private
- */
-function _generateParameters(config, context) {
-    var params = {};
-
-    //default parameters-> where, limit, skip, sort, populate, select, page
-    params.WhereQueryParam = {
-        in: 'query',
-        name: 'where',
-        required: false,
-        type: 'string',
-        description: 'This follows the standard from http://sailsjs.com/documentation/reference/blueprint-api/find-where'
-    };
-    params.LimitQueryParam = {
-        in: 'query',
-        name: 'limit',
-        required: false,
-        type: 'integer',
-        description: 'The maximum number of records to send back (useful for pagination). Defaults to ' + config.blueprints.defaultLimit
-    };
-    params.SkipQueryParam = {
-        in: 'query',
-        name: 'skip',
-        required: false,
-        type: 'integer',
-        description: 'The number of records to skip (useful for pagination).'
-    };
-    params.SortQueryParam = {
-        in: 'query',
-        name: 'sort',
-        required: false,
-        type: 'string',
-        description: 'The sort order. By default, returned records are sorted by primary key value in ascending order. e.g. ?sort=lastName%20ASC'
-    };
-
-    params.PopulateQueryParam = {
-        in: 'query',
-        name: 'populate',
-        required: false,
-        type: 'string',
-        description: 'check for better understanding -> http://sailsjs.com/documentation/reference/blueprint-api/find-where'
-    };
-
-    params.PageQueryParam = {
-        in: 'query',
-        name: 'page',
-        required: false,
-        type: 'integer',
-        description: 'This helps with pagination and when the limit is known'
-    };
-    params.SelectQueryParam = {
-        in: 'query',
-        name: 'select',
-        required: false,
-        type: 'string',
-        description: 'This helps with what to return for the user and its "," delimited'
-    };
-
-    params.TokenHeaderParam = {
-        in: 'header',
-        name: 'token',
-        required: false,
-        type: 'string',
-        description: 'Incase we want to send header information along our request'
-    };
-
-    params.IDPathParam = {
-        in: 'path',
-        name: 'id',
-        required: true,
-        type: 'string',
-        description: 'This is to identify a particular object out'
-    };
-
-    //now we extend our config.swaggerDoc.parameters
-    return _.merge(params, config[context.configKey].parameters);
-}
-
-/**
- * this uses the controllers from our sails application and the routes defined in our config/routes
- * to get out all the necessary routes with their properties defined in @link parsers.routes
- * @param controllers
- * @param config this sails.config
- * @param tags model dictionary for checking if our identity is among our tag
- * @returns {{}}
- * @private
- */
-function _generateRoutes(controllers, config, tags) {
-
-    controllers = _.cloneDeep(controllers);//copy the value out without variable referencing
-    //building all our routes from the custom since the custom over writes the default route
-    var routes = parsers.routes(config.routes);
-
-    _.forEach(controllers, function (controller, identity) {
-        if (!routes[identity])
-            routes[identity] = [];
-
-
-        var blueprints = _.defaults(config.blueprints, {
-            rest: true
-        });
-
-      var prefix = (blueprints.prefix && blueprints.prefix !== '' ? blueprints.prefix : '') + (blueprints.restPrefix && blueprints.restPrefix !== '' ? blueprints.restPrefix : '');
-      if (prefix !== '') prefix += '/';
-        if (blueprints.rest === true) { //if rest is true add this to default routes and actions
-            ///let's extend our controllers for default blue print actions now iff that controller has a model
-            if (_.find(tags, {identity: identity})) {
-                controller = _.merge(controller, {
-                    findOne: {
-                        http_method: 'get',
-                        path:  prefix + identity + '/{id}',
-                        summary: 'Get {identity}',
-                        description: 'This is use to get a single {identity} with the supplied id'
-                    },
-                    find: {
-                        http_method: 'get',
-                        path: prefix + identity,
-                        summary: 'List {identity}',
-                        description: 'This is use to retrieve List of {identity}'
-                    },
-                    create: {
-                        http_method: 'post',
-                        path: prefix + identity,
-                        summary: 'Create {identity}',
-                        description: 'This is use to create new {identity}'
-                    },
-                    update: {
-                        http_method: 'put',
-                        path: prefix + identity + '/{id}',
-                        summary: 'Update {identity}',
-                        description: 'This is for updating our {identity} based on the id'
-                    },
-                    destroy: {
-                        http_method: 'delete',
-                        path: prefix + identity + '/{id}',
-                        summary: 'Delete {identity}',
-                        description: 'This is for deleting specified {identity} with id'
-                    }
-                });
-            }
-        }
-
-        //let's go through all the actions in the controller, excluding identity and globalId
-        var exclude = ['identity', 'globalId', 'sails'];
-        _.forEach(controller, function (value, action) {
-            if (exclude.indexOf(action) > -1)
-                return;
-
-
-            //here we check if it's in our custom routes if so don't add, simply move to the next one
-            if (_.findIndex(routes[identity], {'action': action}) < 0) {
-                routes[identity].push({
-                    http_method: value.http_method || 'get', //as my default
-                    path: value.path || (identity + '/' + action),
-                    action: action,
-                    keys: [], //always empty since they are directly from the controller file and not specified unless default blue prints
-                    summary: value.summary,
-                    description: value.description
-                });
-            }
-
-        });
-
-    });
-
-    return routes;
-}
-
-/**
- * this is used to generate our routes from the generated routes and tags with the custom blue print
- * @param generated_routes
- * @param tags
- * @param customBlueprintMaps
- * @returns {{}}
- * @private
- */
-function _generatePaths(generated_routes, tags, customBlueprintMaps) {
-    var paths = {};
-
-    _.forEach(generated_routes, function (routes, identity) {
-        _.forEach(routes, function (route) {
-
-            var tag = _.find(tags, {identity: identity});
-
-            if (!tag) {
-                //   throw new Error("No tag for this identity-" + identity); --> some controller exist without model
-                console.warn("No tag for this identity '" + identity + "'");
-            }
-
-            var parameter;
-
-          if(!route.custom){ // if not from routes.js use the default custom blueprint maps
-            parameter = formatter.blueprint_parameter(route.action, customBlueprintMaps);
-          }
-
-            if (!parameter) //which means is not in our parameters, then use the keys to get and add token for us incase of any route using header information
-                parameter = _getPathParamsFromKeys(route.keys).concat({$ref: '#/parameters/TokenHeaderParam'});
-
-            var path = {
-                summary: route.summary ? route.summary.replace("{identity}", _.capitalize(identity)) : '',
-                description: route.description ? route.description.replace("{identity}", _.capitalize(identity)) : '',
-                tags: tag ? [tag.name] : [identity],
-                produces: ['application/json'],
-                consumes: ['application/json'],
-                parameters: parameter.concat(_getQueryParamsFromParameters(route.parameters))
-                                     .concat(_getQueryParamsFromRouteQuery(route.query))
-                                     .concat(_getBodyParamsFromRouteBody(route.body)),
-                responses: {
-                    '200': {description: 'The requested resource'},
-                    '404': {description: 'Resource not found'},
-                    '500': {description: 'Internal server error'}
-                }
-            };
-
-            //for our route that alters db we need json form body
-            if (route.action === "create" || route.action === "update") {
-              // check if it contains body already if so no need of adding this, swagger does not allow multiple body
-              if(!_.find(path.parameters, {name: 'body'})){
-                path.parameters.push({
-                    "name": "body",
-                    "in": "body",
-                    "required": true,
-                    "description": "An object defining our schema for " + _.capitalize(identity),
-                    "schema": {"$ref": "#/definitions/" + identity}
-                });
-              }
-            }
-
-            //standardize our link here
-            var link = _standardiseLink(route.path + "/" + _processRouteKeys(route.keys));
-            if (!paths[link]) //if it's undefined create it as empty object for us
-                paths[link] = {};
-
-            paths[link][route.http_method] = path;
-
-        });
-    });
-
-
-    return paths;
-}
-
-/**
- * help to process route keys to swagger spec format
- * which is {key} instead of sails default /:key
- * and also keys with path like so /:key/path --> https://github.com/theo4u/sails-hook-swagger-generator/issues/24
+ * Generate Swagger schema content describing the specified Sails attribute.
  *
- * @param keys
- * @returns {string}
- * @private
+ * @see https://swagger.io/docs/specification/data-models/
+ *
+ * @param {any} attributeInfo Sails model attribute specification as per `Model.js` file
  */
-function _processRouteKeys(keys) {
+function generateAttributeSchema(attributeInfo) {
 
-    var map = _.map(keys, function (key) {
-      // handle keys of such nature specified here: theo4u/sails-hook-swagger-generator#24
-      const keyWithPath = key.split('/');
-      var path = "";
-      if(keyWithPath[1]){
-        path = "/"+ keyWithPath[1]
+  let ai = attributeInfo || {}, sts = formatters.swaggerTypes;
+
+  let type = attributeInfo.type || 'string';
+  let columnType = _.get(attributeInfo, ['autoMigrations', 'columnType']);
+  let autoIncrement = _.get(attributeInfo, ['autoMigrations', 'autoIncrement']);
+
+  let schema = {};
+
+  if (ai.model) {
+
+    _.assign(schema, {
+      description: `JSON dictionary representing the **${ai.model}** instance or FK when creating / updating / not populated`,
+      // '$ref': '#/components/schemas/' + ai.model,
+      oneOf: [ // we use oneOf (rather than simple ref) so description rendered (!) (at least in redocly)
+        { '$ref': '#/components/schemas/' + ai.model },
+      ],
+    });
+
+  } else if (ai.collection) {
+
+    _.assign(schema, {
+      description: `Array of **${ai.collection}**'s or array of FK's when creating / updating / not populated`,
+      type: 'array',
+      items: { '$ref': '#/components/schemas/' + ai.collection },
+    });
+
+  } else if (type == 'number') {
+    let t = autoIncrement ? sts.integer : sts.double;
+    if (ai.isInteger) {
+      t = sts.integer;
+    } else if (columnType) {
+      let ct = columnType;
+      if (ct.match(/int/i)) t = sts.integer;
+      else if (ct.match(/long/i)) t = sts.long;
+      else if (ct.match(/float/i)) t = sts.float;
+      else if (ct.match(/double/i)) t = sts.double;
+      else if (ct.match(/decimal/i)) t = sts.double;
+    }
+    _.assign(schema, t);
+  } else if (type == 'boolean') {
+    _.assign(schema, sts.boolean);
+  } else if (type == 'json') {
+    _.assign(schema, sts.string);
+  } else if (type == 'ref') {
+    let t = sts.string;
+    if (columnType) {
+      let ct = columnType;
+      if (ct.match(/timestamp/i)) t = sts.datetime;
+      else if (ct.match(/datetime/i)) t = sts.datetime;
+      else if (ct.match(/date/i)) t = sts.date;
+    }
+    _.assign(schema, t);
+  } else { // includes =='string'
+    _.assign(schema, sts.string);
+  }
+
+  let isIP = false;
+  if (schema.type == 'string') {
+    let v = ai.validations;
+    if (v) {
+      if (v.isEmail) schema.format = 'email';
+      if (v.isIP) { isIP = true; schema.format = 'ipv4'; }
+      if (v.isURL) schema.format = 'uri';
+      if (v.isUUID) schema.format = 'uuid';
+    }
+  }
+
+  let annotations = [];
+
+  // annotate format with Sails autoCreatedAt/autoUpdatedAt
+  if (schema.type == 'string' && schema.format == 'date-time') {
+    if (ai.autoCreatedAt) annotations.push('autoCreatedAt');
+    else if (ai.autoUpdatedAt) annotations.push('autoUpdatedAt');
+  }
+
+  // process Sails --> Swagger attribute mappings as per sailAttributePropertiesMap
+  let am = formatters.sailAttributePropertiesMap;
+  _.defaults(schema, _.mapKeys(_.pick(ai, _.keys(am)), (v, k) => am[k]));
+
+  // process Sails --> Swagger attribute mappings as per validationsMap
+  let vm = formatters.validationsMap;
+  _.defaults(schema, _.mapKeys(_.pick(ai.validations, _.keys(vm)), (v, k) => vm[k]));
+
+  // copy default into example if present
+  if (schema.default && !schema.example) {
+    schema.example = schema.default;
+  }
+
+  // process final autoMigrations: autoIncrement, unique
+  if (autoIncrement) annotations.push('autoIncrement');
+  if (_.get(attributeInfo, ['autoMigrations', 'unique'])) {
+    schema.uniqueItems = true;
+  }
+
+  // represent Sails `isIP` as one of ipv4/ipv6
+  if (schema.type == 'string' && isIP) {
+    schema = {
+      description: 'ipv4 or ipv6 address',
+      oneOf: [
+        _.cloneDeep(schema),
+        _.assign(_.cloneDeep(schema), { format: 'ipv6' }),
+      ]
+    }
+  }
+
+  if(annotations.length>0) {
+    let s = `Note Sails special attributes: ${annotations.join(', ')}`;
+    schema.description = schema.description ? `\n\n${s}` : s;
+  }
+
+  // note: required --> required[] (not here, needs to be done at model level)
+
+  delete schema.common_name;
+
+  return schema;
+}
+
+/**
+ * Generate Swagger schema content describing specified Sails models.
+ *
+ * @see https://swagger.io/docs/specification/data-models/
+ *
+ * @param {any} models the parsed Sails models as per `parsers.parseModels()`.
+ */
+function generateSchemas(models) {
+
+  let schemas = {};
+
+  _.forEach(models, function (modelInfo) {
+
+    let schema = {
+      description: _.get(modelInfo, ['swagger', 'description']) || `Sails ORM Model **${modelInfo.globalId}**`,
+      properties: {},
+      required: [],
+    };
+
+    _.forEach(modelInfo.attributes, (attributeInfo, attributeName) => {
+      schema.properties[attributeName] = generateAttributeSchema(attributeInfo);
+      if (attributeInfo.required) schema.required.push(attributeName);
+    });
+
+    if (schema.required.length <= 0) delete schema.required;
+
+    schemas[modelInfo.identity] = schema;
+
+  });
+
+  return schemas;
+
+}
+
+/**
+ * Generate Swagger schema content describing specified Sails routes/actions.
+ *
+ * @see https://swagger.io/docs/specification/paths-and-operations/
+ *
+ * @param {any} routes the parsed Sails models as per `parsers.parseCustomRoutes()` / `parsers.parseAllRoutes()`
+ * @param {any} blueprintActionTemplates blueprint action templates; see `formatters.blueprintActionTemplates`
+ * @param {any[]} tags generated Swagger tags to be added to as applicable
+ * @param {any} components generated Swagger components to be added to as applicable
+ * @returns {object} Swagger paths object
+ */
+function generatePaths(routes, blueprintActionTemplates, defaults, tags, components) {
+
+  let paths = {};
+
+  // let defaultBlueprintTagsToAdd = {}; // for blueprint ORM models, keyed on globalId, values `true`
+
+  if(!components.parameters) components.parameters = {};
+
+  function addTags(toAdd) {
+    toAdd.map(tag => {
+      let existing = tags.find(t => t.name == tag.name);
+      if (existing) _.defaults(existing, tag);
+      else tags.push(tag);
+    });
+  }
+
+  function mergeComponents(toMerge) {
+    _.forEach(toMerge, (obj, compName) => {
+      if (!components[compName]) components[compName] = {};
+      _.defaults(components[compName], obj);
+    });
+  }
+
+  _.forEach(routes, routeInfo => {
+
+    let path = routeInfo.swaggerPath || routeInfo.path, pathEntry = {};
+
+    if (routeInfo.middlewareType == 'blueprint') {
+
+      let template = blueprintActionTemplates[routeInfo.blueprintAction] || {};
+
+      let subst = s => s ? s.replace('{globalId}', routeInfo.modelInfo.globalId) : '';
+
+      // handle special case of PK parameter
+      let parameters = [...(template.parameters || [])]
+        .map(p => {
+          if (p === 'primaryKeyPathParameter') {
+            let primaryKey = routeInfo.modelInfo.primaryKey;
+            let attributeInfo = routeInfo.modelInfo.attributes[primaryKey];
+            let pname = 'ModelPKParam-' + routeInfo.identity;
+            if (!components.parameters[pname]) components.parameters[pname] = {
+              in: 'path',
+              name: primaryKey,
+              required: true,
+              schema: generateAttributeSchema(attributeInfo),
+              description: subst('The desired **{globalId}** record\'s primary key value'),
+            };
+            return { $ref: '#/components/parameters/' + pname };
+          }
+          return p;
+        });
+
+      _.defaults(
+        pathEntry,
+        _.omitBy((routeInfo.swagger || {}), (v, k) => k.startsWith('_')),
+        {
+          summary: subst(template.summary),
+          description: subst(template.description),
+          externalDocs: template.externalDocs || undefined,
+          tags: routeInfo.tags,
+          parameters: parameters,
+          responses: _.cloneDeep(template.responses || defaults.responses || {}),
+        }
+      );
+
+      function isParam(_in, _name) {
+        return !!pathEntry.parameters.find(p => p.in == _in && p.name == _name);
       }
-      return "{" + keyWithPath[0] + "}"+path;
-    });
 
-    return map.join("/");
-}
+      let modifiers = {
 
-
-/**
- * making our link string to look like this
- * user/route instead of /user/route/ which is not allowed by swagger spec
- * @param link
- * @returns {*}
- * @private
- */
-function _standardiseLink(link) {
-
-    //check if the first character is / if not add it
-    if (!_.startsWith(link, '/'))
-        link = "/" + link;
-
-    if (_.endsWith(link, '/'))
-        link = link.slice(0, -1); //remove the / by the end
-
-    return link;
-}
-
-/**
- * this is used to generate path param from the route keys
- * @param keys
- * @returns {Array}
- * @private
- */
-function _getPathParamsFromKeys(keys) {
-    var params = [];
-
-    _.forEach(keys, function (key) {
-      const mainKey = key.split('/')[0]; // for keys coming as key/extra_path related to theo4u/sails-hook-swagger-generator#24
-        params.push({
-            in: 'path',
-            name: mainKey,
-            required: true,
-            type: 'string',
-            description: 'This is a path param for ' + mainKey
-        });
-    });
-
-    return params;
-}
-
-/**
- * this is used to create param for custom controllers
- * @param parameters
- * @returns {Array}
- * @private
- */
-function _getQueryParamsFromParameters(parameters) {
-    var params = [];
-
-    _.forEach(parameters, function (parameter) {
-        params.push({
-            in: parameter.in || 'parameters',
-            name: parameter.name,
-            required: parameter.required || false,
-            type: parameter.type || 'string',
-            description: parameter.description || 'This is a custom param for ' + parameter.name
-        });
-    });
-
-    return params;
-}
-
-/**
- * this is used to create param or custom queries for our request or route path
- * @param queries
- * @returns {Array}
- * @private
- */
-function _getQueryParamsFromRouteQuery(queries) {
-    var params = [];
-
-    _.forEach(queries, function (query) {
-        params.push({
+        addPopulateQueryParam: () => {
+          if (isParam('query', 'populate') || routeInfo.associations.length == 0) return;
+          pathEntry.parameters.push({
             in: 'query',
-            name: query,
+            name: 'populate',
             required: false,
-            type: 'string',
-            description: 'This is a query param for ' + query
-        });
-    });
+            schema: {
+              type: 'string',
+              example: ['false', ...(routeInfo.associations.map(row => row.alias) || [])].join(','),
+            },
+            description: 'If specified, overide the default automatic population process.'
+              + ' Accepts a comma-separated list of attribute names for which to populate record values,'
+              + ' or specify `false` to have no attributes populated.',
+          });
 
-    return params;
-}
+        },
 
-/**
- * this is used to create body type of parameter for any request that requires post or put of information
- * @param body
- * @returns {Array}
- * @private
- */
-function _getBodyParamsFromRouteBody(body) {
-    var param = [];
+        addSelectQueryParam: () => {
+          if(isParam('query', 'select')) return;
+          pathEntry.parameters.push({
+            in: 'query',
+            name: 'select',
+            required: false,
+            schema: {
+              type: 'string',
+              example: [..._.keys(routeInfo.modelInfo.attributes || {})].join(','),
+            },
+            description: 'The attributes to include in the result, specified as a comma-delimited list.'
+              + ' By default, all attributes are selected.'
+              + ' Not valid for plural (“collection”) association attributes.',
+          });
 
-    if (!_.isEmpty(body)) {
-        param.push({
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "description": "An object defining our schema for this request",
-            "schema": parsers.attributes(body)
-        });
+        },
+
+        addOmitQueryParam: () => {
+          if(isParam('query', 'omit')) return;
+          pathEntry.parameters.push({
+            in: 'query',
+            name: 'omit',
+            required: false,
+            schema: {
+              type: 'string',
+              example: [..._.keys(routeInfo.modelInfo.attributes || {})].join(','),
+            },
+            description: 'The attributes to exclude from the result, specified as a comma-delimited list.'
+              + ' Cannot be used in conjuction with `select`.'
+              + ' Not valid for plural (“collection”) association attributes.',
+          });
+
+        },
+
+        addModelBodyParam: () => {
+          if (pathEntry.requestBody) return;
+          pathEntry.requestBody = {
+            description: subst('JSON dictionary representing the {globalId} instance to create.'),
+            required: true,
+            content: {
+              'application/json': {
+                schema: { "$ref": "#/components/schemas/" + routeInfo.identity }
+              },
+            },
+          };
+        },
+
+        addResultOfArrayOfModels: () => {
+          _.assign(pathEntry.responses['200'], {
+            description: subst(template.resultDescription),
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { '$ref': '#/components/schemas/' + routeInfo.identity },
+                },
+              },
+            },
+          });
+        },
+
+        addAssociationPathParam: () => {
+          if(isParam('path', 'association')) return;
+          pathEntry.parameters.splice(1, 0, {
+            in: 'path',
+            name: 'association',
+            required: true,
+            schema: {
+              type: 'string',
+              enum: routeInfo.aliases,
+            },
+            description: 'The name of the association',
+          });
+        },
+
+        addAssociationFKPathParam: () => {
+          if(isParam('path', 'fk')) return;
+          pathEntry.parameters.push({
+            in: 'path',
+            name: 'fk',
+            required: true,
+            schema: {
+              oneOf: routeInfo.associationsPrimaryKeyAttributeInfo.map(ai => generateAttributeSchema(ai)),
+            },
+            description: 'The desired target association record\'s foreign key value'
+          });
+        },
+
+        addAssociationResultOfArray: () => {
+          let models = routeInfo.aliases.map(a => {
+            let assoc = routeInfo.associations.find(_assoc => _assoc.alias == a);
+            return assoc ? (assoc.collection || assoc.model) : a;
+          });
+          _.assign(pathEntry.responses['200'], {
+            description: subst(template.resultDescription),
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  // items: { type: 'any' },
+                  items: {
+                    oneOf: models.map(model => {
+                      return { '$ref': '#/components/schemas/' + model };
+                    }),
+                  },
+                },
+              },
+            },
+          });
+        },
+
+        addResultOfModel: () => {
+          _.assign(pathEntry.responses['200'], {
+            description: subst(template.resultDescription),
+            content: {
+              'application/json': {
+                schema: { '$ref': '#/components/schemas/' + routeInfo.identity },
+              },
+            },
+          });
+        },
+
+        addResultNotFound: () => {
+          _.assign(pathEntry.responses['404'], {
+            description: subst(template.notFoundDescription || 'Not found'),
+          });
+        },
+
+        addResultValidationError: () => {
+          _.assign(pathEntry.responses['400'], {
+            description: subst('Validation errors; details in JSON response'),
+          });
+        },
+
+        addFksBodyParam: () => {
+          if (pathEntry.requestBody) return;
+          pathEntry.requestBody = {
+            description: 'The primary key values (usually IDs) of the child records to use as the new members of this collection',
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    oneOf: routeInfo.associationsPrimaryKeyAttributeInfo.map(ai => generateAttributeSchema(ai)),
+                  },
+                },
+              },
+            },
+          };
+        },
+
+      };
+
+      // apply changes for blueprint action
+      (template.modifiers || []).map(m => {
+        if (_.isFunction(m)) m(template, routeInfo, pathEntry, tags, components); // custom modifier
+        else modifiers[m](); // standard modifier
+      });
+
+      _.assign(pathEntry.responses['500'], {
+        description: 'Internal server error',
+      });
+
+    } else if (routeInfo.middlewareType == 'action') {
+
+      // initial defaults as actions2 may populate parameters and responses (more below)
+      _.defaults(
+        pathEntry,
+        _.omitBy((routeInfo.swagger || {}), (v, k) => k.startsWith('_')),
+        {
+          parameters: [],
+          responses: _.cloneDeep(defaults.responses || {}),
+        }
+      );
+
+      if (routeInfo.actions2) {
+        let a2 = routeInfo.actions2;
+        let pv = routeInfo.patternVariables || [];
+
+        if (a2.inputs) {
+          _.forEach(a2.inputs, (v, k) => {
+            let _in = pv.indexOf(k) >= 0 ? 'path' : 'query';
+            let existing = pathEntry.parameters.find(p => p.in == _in && p.name == k);
+            if (existing) return;
+            pathEntry.parameters.push({
+              in: _in,
+              name: k,
+              required: v.required || false,
+              schema: generateAttributeSchema(_.omit(v, 'description')),
+              description: v.description || undefined,
+            });
+          });
+        }
+
+        if (a2.exits) {
+          let exitResponses = {};
+
+          // actions2 may specify more than one 'exit' per 'statusCode' --> use oneOf
+          _.forEach(a2.exits, (exit, exitName) => {
+            let a2r = formatters.actions2Responses;
+            let { statusCode, description } = a2r[exitName] || a2r.success;
+            statusCode = exit.statusCode || statusCode;
+            description = exit.description || description;
+
+            if (exitResponses[statusCode]) {
+              let arr = _.get(pathEntry, ['responses', statusCode, 'content', 'application/json', 'schema', 'oneOf']);
+              arr.push({ type: 'json', description: description });
+            } else {
+              exitResponses[statusCode] = {
+                description: description,
+                content: {
+                  'application/json': {
+                    schema: { oneOf: [{ type: 'object', description: description },], },
+                  },
+                },
+              };
+            }
+          });
+
+          // remove oneOf for single entries, otherwise summarise
+          _.forEach(exitResponses, (resp, sc) => {
+            let arr = _.get(resp, ['content', 'application/json', 'schema', 'oneOf']);
+            if (arr.length == 1) {
+              _.set(resp, ['content', 'application/json', 'schema'], arr[0]);
+            } else {
+              resp.description = `${arr.length} alternative responses`;
+            }
+          });
+
+          _.defaults(pathEntry.responses, exitResponses);
+          _.forEach(pathEntry.responses, (v,k) => { // ensure description
+            if(!v.description) v.description = _.get(exitResponses, [k, 'description'], '-');
+          });
+        }
+
+        // actions2 summary and description
+        _.defaults(
+          pathEntry,
+          {
+            summary: _.get(routeInfo, ['actions2', 'friendlyName']) || routeInfo.actionPath || '',
+            description: _.get(routeInfo, ['actions2', 'description']) || undefined,
+          }
+        );
+      }
+
+      // final populate noting others above
+      _.defaults(
+        pathEntry,
+        {
+          summary: routeInfo.actionPath || '',
+          tags: routeInfo.tags,
+        }
+      );
+
+    } else {
+
+      sails.log.warn(`WARNING: sails-hook-swagger-generator: Cannot generate path for ${routeInfo.path}`);
+
     }
 
-    return param;
+    if (routeInfo.patternVariables) {
+
+      // first resolve '$ref' parameters
+      let resolved = pathEntry.parameters.map(p => {
+        let ref = p['$ref'];
+        if (!ref) return p;
+        let _prefix = '#/components/parameters/';
+        if (ref.startsWith(_prefix)) {
+          ref = ref.substring(_prefix.length);
+          let dereferenced = components.parameters[ref];
+          return dereferenced ? dereferenced : p;
+        }
+      });
+
+      // now add patternVariables that don't already exist
+      routeInfo.patternVariables.map(v => {
+        let existing = resolved.find(p => p.in == 'path' && p.name == v);
+        if (existing) return;
+        pathEntry.parameters.push({
+          in: 'path',
+          name: v,
+          required: true,
+          schema: { type: 'string' },
+          description: `Route pattern variable \`${v}\``,
+        });
+      });
+
+    }
+
+    addTags(_.get(routeInfo.swagger, '_tags', []));
+    mergeComponents(_.get(routeInfo.swagger, '_components'));
+
+    _.set(paths, [path, routeInfo.httpMethod], pathEntry);
+
+  });
+
+  return paths;
+
 }
 
-
 module.exports = {
-    tags: _generateModels,
-    definitions: _generateDefinitions,
-    parameters: _generateParameters,
-    routes: _generateRoutes,
-    paths: _generatePaths
+  generateSchemas: generateSchemas,
+  generatePaths: generatePaths,
 };

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,151 +1,709 @@
 /**
  * Created by theophy on 02/08/2017.
  */
-var formatters = require('./type-formatter');
-var _ = require('lodash');
+const _ = require('lodash');
+const _path = require('path');
+const swaggerJSDoc = require('swagger-jsdoc');
 
+const formatters = require('./type-formatter');
 
 /**
- * this is used to parse our attributes to give us the properties and required field and it's based
- * on swagger specifications, so we map each sails types to swagger types
- * and also validation rules are added for just the ones handles in our @link type-formatter.js
- * @param attributes
- * @returns {{properties: {}, required: Array}}
- * @private
+ * Parses Sails model information and returns `modelInfo` objects keyed on `globalId`.
+ *
+ * @param {any} sailsConfig the `sails.config` object
+ * @param {any} sailsModels the `sails.models` object
+ * @returns { [globalId:string]: { tag:string, globalId:string, identity:string, primaryKey:string, attributes:[], swagger:{ _tags:[], _components:{} } } }
  */
-function _parseAttributes(attributes) {
-    var properties = {};
-    var required = [];
-    _.forEach(attributes, function (attribute, name) {
-        var property = {};
-        let columnType = attribute.autoMigrations ? attribute.autoMigrations.columnType : undefined;
-        property[name] = _.clone(formatters.attribute_type(attribute.type, columnType));//dereference our object here
+function parseModels(sailsConfig, sailsModels) {
 
-        //filter out required fields here
-        if (_.has(attribute, 'required') && attribute.required === true)
-            required.push(name);
+  let models = {};
 
-        //scan through validation types
-        _.forEach(attribute, function (value, rule) {
-            rule = formatters.validation_type(rule); //transform rule here
-            if (rule) {//if it is existing in our formatter add it else leave it
-                property[name][rule] = value;
-            }
-        });
+  let jsDocCache = {};
 
-        _.merge(properties, property);//add the property to our properties
+  _.forEach(sailsModels, model => {
+
+    // consider all models except associative tables and 'Archive' model special case
+    if (!model.globalId || model.globalId == 'Archive') return;
+
+    let swagger = {};
+
+    let actionNames = ['findone', 'find', 'create', 'update', 'destroy', 'populate', 'add', 'remove', 'replace'];
+
+    mergeSwagger(swagger, model.swagger);
+
+    // collect `_{blueprintAction}` swagger definitions
+    _.forEach(model.swagger, (v, k) => {
+      if (!k.startsWith('_')) return;
+      if (!swagger[k]) swagger[k] = {};
+      mergeSwagger(swagger[k], v);
     });
 
-    var parsed = {properties: properties, required: required};
-    if (parsed.required.length === 0) //if the required field is empty we remove it, not needed
-        delete parsed.required;
+    try {
+      let dir = sailsConfig.paths.models;
+      let pth = require.resolve(_path.join(dir, model.globalId));
+      if (pth) {
+        loadAndMergeJsDoc(jsDocCache, swagger, pth, model.globalId);
 
-    return parsed;
+        // collect `/{blueprintAction}` swagger definitions
+        _.forEach(
+          _.get(jsDocCache, [pth, 'paths']),
+          (v, k) => {
+            if(k==('/'+model.globalId)) return; // skip, handled above
+            let ba = '_' + k.substring(1);
+            if (!swagger[ba]) swagger[ba] = {};
+            mergeSwagger(swagger[ba], v);
+          }
+        );
+      }
+    } catch (error) {
+      sails.log.error(`ERROR: sails-hook-swagger-generator: Error resolving/loading model ${model.globalId}: ${error.message || ''}`, error);
+    }
+
+    let modelInfo = {
+      tags: swagger.tags || [model.globalId], // default name of Swagger group based on model globalId
+      globalId: model.globalId, // model globalId
+      identity: model.identity, // model identity
+      primaryKey: model.primaryKey || 'id', // name of primary key attribute
+      attributes: _.cloneDeep(model.attributes), // attribute definition as per Sails model definition
+      swagger: swagger, // model-specific swagger (see below)
+    };
+
+    let defaultDescription = `Sails blueprint actions for the **${model.globalId}** model`;
+
+    let tagDefs = getOrSet(swagger, '_tags', []);
+    modelInfo.tags.map(tagName => {
+      let existing = tagDefs.find(t => t.name == tagName);
+      if (existing) {
+        if (!existing.description) existing.description = defaultDescription;
+      } else {
+        tagDefs.push({ name: tagName, description: defaultDescription });
+      }
+    });
+
+    models[model.globalId] = modelInfo;
+
+  });
+
+  return models;
+
 }
 
 /**
- * this is used to parse our routes from config/routes then break it down
- * to a form which is readable and transversing is easy
- * for all route under an {identity:[http_method,path,action]
- * @param routes
- * @returns {{}}
- * @private
+ * Parse Sails custom routes and returns an array of `routeInfo` objects.
+ *
+ * @param {any} sailsConfig the `sails.config` object
+ * @returns array of `routeInfo` objects (see documentation in-code below)
  */
-function _parseRoutes(routes) {
-    var custom_routes = {};
+function parseCustomRoutes(sailsConfig) {
 
-    /**
-     * we need to check for routes without verb or method
-     * which means for a path allow any CRUD method (GET, PUT, POST, DELETE or PATCH) when a method is not specified
-     * so we create dublicate and prepend the http method or verb
-     */
+  let customRoutes = [];
 
-    routes = _handleRoutesWithNoVerb(routes);
+  let jsDocCache = {};
 
+  _.forEach(sailsConfig.routes, (target, address) => {
 
-    _.forEach(routes, function (controller_action, method_path) {
-        if (method_path === "/csrfToken") //exclude this csrfToken route not needed
-            return;
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?route-address
+    let [verb, path] = address.split(/\s+/);
+    if (path === undefined) {
+      path = verb;
+      verb = 'all';
+    }
 
-        /**
-         * for those route using object instead of regular 'method path'.'controller.action'
-         * we remove the swagger option if available
-         * @type {{}}
-         */
-        var swagger_property = {};
-        if (_.isObject(controller_action)) {
-            swagger_property = controller_action.swagger;
-            controller_action = controller_action.controller + "." + controller_action.action;
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?wildcards-and-dynamic-parameters
+    let { patternVariables, swaggerPath } = generateSwaggerPath(path);
+
+    // XXX TODO wildcard
+
+    // XXX TODO Handle arrays
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?route-target
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?policy-target-syntax
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?function-target-syntax
+
+    // XXX TODO Handle these variations
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?regular-expressions-in-addresses
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?routing-to-blueprint-actions
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?redirect-target-syntax (starts with / or scheme)
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?response-target-syntax
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?policy-target-syntax
+    // https://sailsjs.com/documentation/concepts/actions-and-controllers#?actions-2
+
+    // parse target
+    let middlewareType = 'action', controller = '?', action = '?', actionType = '?', actionFound = '?', actionSwagger = {}, actions2;
+
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?controller-action-target-syntax
+    // https://sailsjs.com/documentation/concepts/routes/custom-routes#?standalone-action-target-syntax
+    if (_.isString(target)) {
+      let match;
+      if (match = target.match(/^([^.]+Controller)\.([^.]+)$/)) { // 'FooController.myGoAction'
+        [, controller, action] = match;
+        actionType = 'controller';
+      } else if (match = target.match(/^([^.]+)\.([^.]+)$/)) { // 'foo.myGoAction'
+        [, controller, action] = match;
+        controller = toController(controller);
+        actionType = 'controller';
+      } else if (match = target.match(/^([^.]+)$/)) { // 'foo/go-action'
+        controller = null;
+        [, action] = match;
+        actionType = 'standalone';
+      }
+    } else if (_.isObject(target)) {
+      // { controller: 'foo', action: 'myGoAction' }
+      // OR { controller: 'FooController', action:'myGoAction' }
+      if (target.controller && target.action) {
+        ({ controller, action } = target);
+        if (!controller.endsWith('Controller')) controller = toController(controller);
+        actionType = 'controller';
+      } else if (target.action) { // { action: 'foo/go-action' }
+        controller = null;
+        ({ action } = target);
+        actionType = 'standalone';
+      } else if (target.view) {
+        // https://sailsjs.com/documentation/concepts/routes/custom-routes#?view-target-syntax
+        middlewareType = 'view';
+      }
+      mergeSwagger(actionSwagger, target.swagger);
+    }
+
+    // load any JSDoc in config/routes.js
+    try {
+      let dir = sailsConfig.paths.config;
+      let pth = require.resolve(_path.join(dir, 'routes'));
+      if (pth) {
+        loadAndMergeJsDoc(jsDocCache, actionSwagger, pth, path.substring(1), verb);
+      }
+    } catch (error) {
+      sails.log.error(`ERROR: sails-hook-swagger-generator: Error (ignoring) resolving/loading config/routes.js: ${error.message || ''}`, error);
+    }
+
+    if (action) {
+      ({ status:actionFound, actions2 } = testLoadAction(sailsConfig, jsDocCache, actionSwagger, controller, action));
+    }
+
+    // check for 'foo/go-action' --> FooController.go-action
+    if (!controller && action && actionType == 'standalone' && actionFound == 'notfound') {
+      let _controller = _path.dirname(action);
+      if (_controller != '.') {
+        _controller = toController(_controller);
+        let _action = _path.basename(action);
+        let { status:_actionFound } = testLoadAction(sailsConfig, jsDocCache, actionSwagger, _controller, _action);
+        if (_actionFound == 'loaded+found') {
+          // if FooController.go-action, update details
+          controller = _controller;
+          action = _action;
+          actionType = 'controller';
+          actionFound = _actionFound;
         }
+      }
+    }
 
-        var model_identity = controller_action.substring(0, controller_action.indexOf("Controller")).toLowerCase();
-        method_path = method_path.split(/ (.+)/);//get only the first instance of our space splitting
+    let tag = controller ? controller.substring(0, controller.length - 10) : action;
+    let actionPath = (controller ? _path.join(tag, action) : action).toLowerCase();
 
-        if (!custom_routes[model_identity])   //first time
-            custom_routes[model_identity] = [];//declare as array
+    let routeInfo = {
+      middlewareType: middlewareType, // one of action|blueprint|view
+      blueprintAction: undefined, // optional; one of findone|find|create|update|destroy|populate|add|remove|replace or custom
+      httpMethod: verb.toLowerCase(), // one of all|get|post|put|patch|delete
+      path: path, // full Sails URL as per sails.getUrlFor() including prefix
+      swaggerPath: swaggerPath, // full Sails URL with ':token' replaced with '{token}' for use with Swagger
+      identity: undefined, // optional (present for blueprints only); Sails Model identity
+      modelInfo: undefined, // optional (present for blueprints only); Sails Model metadata
+      controller: controller, // Sails Controller relative path including 'Controller' suffix
+      tags: [tag], // default name of Swagger group based on Sails controller/action or Sails Model globalId
+      actionPath: actionPath, // Sails Controller action path consistent with 'router:bind' events (controller relative path without suffix + action name)
+      actionName: action, // Sails Controller action name e.g. findone or buildModels
+      actionType: actionType, // one of controller|standalone|actions2
+      actionFound: actionFound, // one of notfound|loaded+notfound|loaded+found|implicit
+      actions2: actions2, // optional; present for custom routes with actions2 actions
+      patternVariables: patternVariables, // route dynamic parameters
+      associations: undefined, // optional (present for blueprints only); Sails Model associations
+      aliases: undefined, // optional (applicable for populate blueprints only); Sails Model attribute names for populate action(s)
+      associationsPrimaryKeyAttributeInfo: undefined, // optional (present for blueprints only); array of attributeInfo's for association PKs
+      swagger: actionSwagger, // per-route swagger (see below)
+    };
 
-        var full_path = method_path[1].trim().split("/:");
+    if (verb != 'all') {
+      customRoutes.push(routeInfo);
+    } else {
+      ['get', 'post', 'put', 'patch', 'delete'].map(v => {
+        customRoutes.push(_.defaults({ httpMethod: v }, _.cloneDeep(routeInfo)));
+      });
+    }
 
-        //now we extend and use the swagger to override our default route property, incase the user wants to change description and summary
-        var property = _.defaults(swagger_property, {
-            http_method: method_path[0].trim().toLowerCase(),
-            path: full_path[0],
-            action: controller_action.substring(controller_action.indexOf(".") + 1), //remove the .
-            keys: full_path.splice(1),//remove the first initial path and return the split as array
-            summary: '',
-            description: '',
-            body: {}, //format as sails attributes, {field:{type,validation...}, ...}
-            query: [],//array of the query types
-            custom: true // to differentiate custom route from route.js
-        });
+  });
 
-        //we don't need the body if it's not for post or put
-        if (property.http_method !== 'post' && property.http_method !== 'put') {
-            delete property.body;
-        }
-
-
-        custom_routes[model_identity].push(property);
-    });
-
-    return custom_routes;
+  return customRoutes;
 }
 
 /**
- * this is used to handle routes with no verb or http method
- * which means for a path allow any CRUD method (GET, PUT, POST, DELETE or PATCH) when a method is not specified
- * so we create dublicate and prepend the http method or verb
- * @param routes
- * @returns {*}
- * @private
+ * Parses specified Sails routes and return an array of `routeInfo` objects.
+ *
+ * @see https://github.com/balderdashy/sails/blob/master/lib/EVENTS.md#routerbind
+ *
+ * @param {object[]} sailsRoutes array of `routeObj`'s from `router:bind` event
+ * @param {object} models `modelInfo` objects keyed on `globalId` as per `parseModels()`
+ * @param {object} sailsConfig the `sails.config` object
+ * @returns array of `routeInfo` objects (see documentation in-code below)
  */
-function _handleRoutesWithNoVerb(routes) {
-    var refined_routes = _.clone(routes);
+function parseAllRoutes(sailsRoutes, models, sailsConfig) {
 
-    _.forEach(routes, function (controller_action, method_path) {
-        if (method_path === "/csrfToken") //exclude this csrfToken route not needed
-            return;
+  // there seems to be duplicates in the routes, so merge them here to capture maximum metadata
+  let routesByPath = {};
+  _.forEach(sailsRoutes, _route => {
+    if (!_route.path || !_route.verb) {
+      sails.log.warn(`WARNING: sails-hook-swagger-generator: Bad route ${_route.verb} ${_route.path} (ignoring)`);
+      return;
+    }
+    let key = [_route.verb, _route.path].join(' ');
+    let val = _.defaults({ path: _route.path, verb: _route.verb }, _route.options);
+    if (_.isEqual(val, routesByPath[key])) return;
+    _.defaults(val, routesByPath[key]);
+    routesByPath[key] = val;
+  });
 
-        method_path = method_path.split(/ (.+)/);//get only the first instance of our space splitting
+  let _routes = [];
 
-        if (method_path.length === 1) { //means no verb just path
-            refined_routes['post ' + method_path[0]] = controller_action;
-            refined_routes['get ' + method_path[0]] = controller_action;
-            refined_routes['put ' + method_path[0]] = controller_action;
-            refined_routes['delete ' + method_path[0]] = controller_action;
-            refined_routes['patch ' + method_path[0]] = controller_action;
+  _.forEach(routesByPath, routeObj => {
 
-            // now delete the current key without verb or http method
-            delete refined_routes[method_path[0]];
+    let middlewareType = '?', blueprintAction, identity, modelInfo, controller = '?', tags, actionName = '?', actionType = '?', actionFound = '?', modelSwagger;
+
+    let { patternVariables, swaggerPath } = generateSwaggerPath(routeObj.path);
+
+    let associationPrimaryKeyAttributeInfo;
+
+    if (routeObj._middlewareType) {
+      // ACTION | BLUEPRINT | CORS HOOK | POLICY | VIEWS HOOK | CSRF HOOK | * HOOK
+      let match = routeObj._middlewareType.match(/^([^:]+):\s+(.+)$/);
+      if (match) {
+        middlewareType = match[1].toLowerCase();
+        actionName = match[2].toLowerCase();
+        if (middlewareType != 'action' && middlewareType != 'blueprint') {
+          // sails.log.warn(`WARNING: sails-hook-swagger-generator: Unrecognised middlewareType '${routeObj._middlewareType}' for ${routeObj.path}`);
+          return;
         }
+      } else {
+        sails.log.warn(`WARNING: sails-hook-swagger-generator: Unrecognised middlewareType '${routeObj._middlewareType}' for ${routeObj.path}`);
+      }
+    }
 
-    });
+    if (middlewareType == 'blueprint') {
 
+      blueprintAction = actionName;
+      identity = routeObj.model;
+      if (!identity && routeObj.action) {
+        // custom blueprint actions may not have model name explicitly specified --> extract from action
+        [identity] = routeObj.action.split('/');
+      }
+      modelInfo = _.find(models, model => model.identity == identity);
+      if (!modelInfo) {
+        sails.log.warn(`WARNING: sails-hook-swagger-generator: Ignoring unregconised shadow/implicit route ${routeObj.path} (type ${middlewareType}) referencing unknown model ${identity}`);
+        return;
+      }
+      controller = toController(modelInfo.globalId);
+      tags = modelInfo.tags;
+      actionType = 'controller';
+      actionFound = 'implicit';
 
-    return refined_routes;
+      modelSwagger = mergeSwagger(
+        {},
+        _.get(modelInfo.swagger, '_' + blueprintAction, {}),
+        _.get(modelInfo.swagger, '_tags'),
+        _.get(modelInfo.swagger, '_components')
+      );
+
+      if (routeObj.associations && routeObj.alias) {
+        associationPrimaryKeyAttributeInfo = function () {
+          let _assoc = routeObj.associations.find(a => a.alias == routeObj.alias);
+          if (!_assoc) return;
+          let _identity = _assoc.collection || _assoc.model;
+          let _modelInfo = _.find(models, model => model.identity == _identity);
+          if (!_modelInfo) return;
+          let ret = _.cloneDeep(_modelInfo.attributes[_modelInfo.primaryKey]);
+          ret.description = `**${_modelInfo.globalId}** record's foreign key value (**${routeObj.alias}** association${ret.description ? '; ' + ret.description : ''})`;
+          return ret;
+        }();
+      }
+
+      if (modelInfo.primaryKey !== 'id') {
+        swaggerPath = swaggerPath.replace('{id}', '{' + modelInfo.primaryKey + '}');
+      }
+
+    } else if (middlewareType == 'action') {
+
+      actionName = '?'; // case of controller/action is flattened by Sails --> easier to obtain from custom routes
+
+    }
+
+    let routeInfo = {
+      middlewareType: middlewareType, // one of action|blueprint|view
+      blueprintAction: blueprintAction, // optional; one of findone|find|create|update|destroy|populate|add|remove|replace or custom
+      httpMethod: routeObj.verb.toLowerCase(), // one of all|get|post|put|patch|delete
+      path: routeObj.path, // full Sails URL as per sails.getUrlFor() including prefix
+      swaggerPath: swaggerPath, // full Sails URL with ':token' replaced with '{token}' for use with Swagger
+      identity: identity, // optional (present for blueprints only); Sails Model identity
+      modelInfo: modelInfo, // optional (present for blueprints only); Sails Model metadata
+      controller: controller, // Sails Controller relative path including 'Controller' suffix
+      tags: tags || [], // default name of Swagger group based on Sails controller/action or Sails Model globalId
+      actionPath: routeObj.action, // Sails Controller action path consistent with 'router:bind' events (controller relative path without suffix + action name)
+      actionName: actionName, // Sails Controller action name e.g. findone or buildModels
+      actionType: actionType, // one of controller|standalone|actions2
+      actionFound: actionFound, // one of notfound|loaded+notfound|loaded+found|implicit
+      actions2: undefined, // optional; present for custom routes with actions2 actions
+      patternVariables: patternVariables, // optional; route dynamic parameters
+      associations: routeObj.associations || [], // optional (present for blueprints only); Sails Model associations
+      alias: routeObj.alias || undefined, // optional (applicable for populate blueprints only); Sails Model attribute name for populate actions
+      // ^ replaced by `aliases` below (plural after aggregation)
+      associationPrimaryKeyAttributeInfo: associationPrimaryKeyAttributeInfo, // optional (present for blueprints only); alias attributeInfo for association PK
+      // ^ replaced by `associationsPrimaryKeyAttributeInfo` below (plural after aggregation)
+      swagger: modelSwagger, // per-route swagger (see below)
+    };
+
+    _routes.push(routeInfo);
+
+  });
+
+  /*
+   * Sails returns individual routes for each association:
+   * - /api/v1/quote/:parentid/supplier/:childid
+   * - /api/v1/quote/:parentid/items/:childid
+   *
+   * We now aggreggate these routes.
+   */
+
+  let populateByModel = {}, addByModel = {}, removeByModel = {}, replaceByModel = {};
+  _routes.map(routeInfo => {
+
+    // only blueprint actions
+    if (routeInfo.middlewareType != 'blueprint') return;
+
+    let m = routeInfo.identity;
+    function addTo(ba, tgt) {
+      if (routeInfo.blueprintAction != ba) return;
+      if (!tgt[m]) tgt[m] = [];
+      tgt[m].push(routeInfo);
+    }
+    addTo('populate', populateByModel);
+    addTo('add', addByModel);
+    addTo('remove', removeByModel);
+    addTo('replace', replaceByModel);
+  });
+
+  _routes = _routes
+    .map(routeInfo => {
+
+      // only blueprint actions
+      if (routeInfo.middlewareType != 'blueprint') return routeInfo;
+
+      let m = routeInfo.identity;
+      let pk = routeInfo.modelInfo.primaryKey;
+
+      function process(tgt) {
+        let arr = tgt[m];
+        if (!arr) return undefined; // emit aggregated routeInfo on first occurence
+
+        let re = new RegExp('/{parentid}/' + routeInfo.alias + '$', 'g');
+        routeInfo.swaggerPath = routeInfo.swaggerPath.replace(re, `/{${pk}}/{association}`);
+
+        re = new RegExp('/{parentid}/' + routeInfo.alias + '/{childid}$', 'g');
+        routeInfo.swaggerPath = routeInfo.swaggerPath.replace(re, `/{${pk}}/{association}/{fk}`);
+
+        routeInfo.aliases = arr.map(ri => ri.alias);
+        routeInfo.associationsPrimaryKeyAttributeInfo = arr.map(ri => ri.associationPrimaryKeyAttributeInfo);
+        delete routeInfo.alias;
+        delete routeInfo.associationPrimaryKeyAttributeInfo;
+
+        delete tgt[m];
+        return routeInfo;
+      }
+      if (routeInfo.blueprintAction == 'populate') return process(populateByModel);
+      if (routeInfo.blueprintAction == 'add') return process(addByModel);
+      if (routeInfo.blueprintAction == 'remove') return process(removeByModel);
+      if (routeInfo.blueprintAction == 'replace') return process(replaceByModel);
+
+      return routeInfo;
+
+    })
+    .filter(routeInfo => routeInfo);
+
+  return _routes;
+
 }
+
+/**
+ * Merge custom routes (from `config/routes.js`) and 'all' routes (from router bind events),
+ * removing duplicates where necessary.
+ *
+ * Notes:
+ * 1. 'Custom' routes contain Swagger documention from source and JSDoc.
+ * 2. 'All' routes contain Swagger documentation from `api/models/*.js` for blueprint routes.
+ * 3. 'All' routes contain more detail for custom route actions which resolve to blueprint actions
+ *    but miss custom route Swagger documentation.
+ *
+ * @param {object[]} customRoutes array of `routeInfo` objects from `parseCustomRoutes()`
+ * @param {object[]} allRoutes array of `routeInfo` objects from `parseAllRoutes()`
+ * @returns {object[]} array of `routeInfo` objects
+ */
+function mergeCustomAndAllRoutes(customRoutes, allRoutes) {
+
+  let merged = allRoutes.map(ar => {
+
+    let cr = customRoutes.find(_cr => _cr.path == ar.path && _cr.httpMethod == ar.httpMethod);
+    if(!cr) return ar;
+
+    if(ar.middlewareType=='blueprint') {
+      // if resolves to blueprint, use this merging in any Swagger documention from custom route
+      let swagger = _.cloneDeep(cr.swagger);
+      mergeSwagger(swagger, ar.swagger);
+      return _.assign(_.cloneDeep(ar), { swagger: swagger });
+    } else if(ar.middlewareType=='action') {
+      // for actions, prefer custom routes
+      return _.cloneDeep(cr);
+    } else {
+      // default to custom route
+      return _.cloneDeep(cr);
+    }
+
+  });
+
+  customRoutes.map(cr => {
+    let r = merged.find(m => m.path == cr.path && m.httpMethod == cr.httpMethod);
+    if(!r) {
+      sails.log.warn(`WARNING: sails-hook-swagger-generator: Sails custom route ${cr.path} NOT found as bound route (ignoring)`);
+    }
+  })
+
+  return merged;
+
+}
+
+/**
+ * Converts controller syntax from `path/foo` to `path/FooController`.
+ * @param {string} path
+ * @returns converted path
+ */
+function toController(path) {
+  let dir = _path.dirname(path);
+  let controller = _path.basename(path);
+  controller = controller.charAt(0).toUpperCase() + controller.substring(1) + 'Controller';
+  return _path.join(dir, controller);
+}
+
+/**
+ * Attempts to load Sails controller action JavaScript file, merge any Swagger content
+ * (in-code and/or JSDoc) and return actions2 metadata if applicable.
+ *
+ * @param {any} sailsConfig the `sails.config` object
+ * @param {any} jsDocCache object cached used across multiple calls
+ * @param {any} swagger object into which to load and merge Swagger content
+ * @param {string} controller relative path of the Sails controller file (or empty for standalone action)
+ * @param {string} action name of the action within the controller file or relative path for standalone action
+ * @return { status: notfound|loaded+notfound|loaded+found|loaded+found+actions2, actions2: {} }
+ */
+function testLoadAction(sailsConfig, jsDocCache, swagger, controller, action) {
+  let dir = sailsConfig.paths.controllers;
+  try {
+    if (controller) {
+      let pth = _path.join(dir, controller);
+      let module = require(pth);
+      if (module[action]) {
+        mergeSwagger(swagger, module[action].swagger);
+        mergeSwagger(
+          swagger,
+          _.get(module, ['swagger', '_' + action]),
+          _.get(module, ['swagger', '_tags'], []),
+          _.get(module, ['swagger', '_components'], {}),
+        );
+
+        let rpth = require.resolve(pth);
+        loadAndMergeJsDoc(jsDocCache, swagger, rpth, action);
+
+        return { status: 'loaded+found' };
+      } else {
+        return { status: 'loaded+notfound' };
+      }
+    } else {
+      let pth = _path.join(dir, action);
+      let module = require(pth);
+
+      mergeSwagger(swagger, module.swagger);
+
+      let rpth = require.resolve(pth);
+      loadAndMergeJsDoc(jsDocCache, swagger, rpth, _path.basename(action));
+
+      if (_.isFunction(module)) { // standalone action
+        return { status: 'loaded+found' };
+      } else { // actions2
+        return { status: 'loaded+found', actions2: _.omit(module, 'fn') };
+      }
+    }
+  } catch (error) {
+    return { status: 'notfound' };
+  }
+};
+
+/**
+ * Attempts to load specified source file, parse JSDoc and merge any
+ * `@swagger` annotated comments.
+ *
+ * @param {any} jsDocCache object cached used across multiple calls
+ * @param {any} swagger object into which to merge loaded Swagger content
+ * @param {string} path path of file to load and parse JSDoc from
+ * @param {string} actionOrPath Sails action within the target file, or relative path (no leading '/')
+ * @param {string} httpMethod optional HTTP method used as sub-element under actionOrPath within Swagger content
+ */
+function loadAndMergeJsDoc(jsDocCache, swagger, path, actionOrPath, httpMethod) {
+
+  let _swagger;
+  if (jsDocCache[path]) {
+    _swagger = jsDocCache[path];
+  } else {
+    try {
+      let opts = {
+        definition: {
+          openapi: '3.0.0', // Specification (optional, defaults to swagger: '2.0')
+          info: { title: 'dummy', version: '0.0.0' },
+        },
+        apis: [path],
+      };
+      _swagger = swaggerJSDoc(opts);
+      if (_swagger) jsDocCache[path] = _swagger;
+
+    } catch (error) {
+      sails.log.warn(`WARNING: sails-hook-swagger-generator: Error loading/parsing JSDoc ${path}: ${error.message || ''}`, error);
+      _swagger = {};
+      jsDocCache[path] = {}; // cache empty result so report error only once
+    }
+  }
+
+  if (_swagger) {
+    let srcSwagger = httpMethod ? _.get(_swagger, ['paths', '/' + actionOrPath, httpMethod])
+      : _.get(_swagger, ['paths', '/' + actionOrPath]);
+    mergeSwagger(
+      swagger,
+      srcSwagger,
+      _.get(_swagger, 'tags', []),
+      _.get(_swagger, 'components', {})
+    );
+  }
+
+}
+
+/**
+ * Maps from a Sails route path of the form `/path/:id` to a
+ * Swagger path of the form `/path/{id}`.
+ *
+ * @param {string} path
+ * @returns { patternVariables:string[], swaggerPath:string }
+ */
+function generateSwaggerPath(path) {
+  let patternVariables = [];
+  let swaggerPath = path
+    .split('/')
+    .map(v => {
+      let match = v.match(/^:([^/:?]+)\??$/);
+      if (match) {
+        patternVariables.push(match[1]);
+        return '{' + match[1] + '}';
+      }
+      return v;
+    })
+    .join('/');
+  return { patternVariables: patternVariables, swaggerPath: swaggerPath };
+}
+
+/**
+ * Gets and returns the specified lodash path, setting if dne.
+ * @param {*} object object to operate on
+ * @param {*} path path (as per `_.get()`) within `object`
+ * @param {*} defaultValue default value to set if `path` not set
+ * @returns {any} requested path within object
+ */
+function getOrSet(object, path, defaultValue) {
+  let v = _.get(object, path);
+  if (v !== undefined) return v;
+  _.set(object, path, defaultValue);
+  return defaultValue;
+}
+
+/**
+ * Takes source Swagger content, incuding additions for tags and components,
+ * and merges into the destination Swagger content.
+ *
+ * @see Tag and component element handing in README for notes on merging
+ * @see The reference object `componentDefinitionReference` below
+ *
+ * @param {any} destSwagger object into which to merge loaded Swagger content
+ * @param {any} srcSwagger object from which to extract Swagger content *for* merging
+ * @param {any} tags object from which to extract Swagger tag definitions *for* merging; defaults to `['_tags']` element
+ * @param {any} components object from which to extract Swagger component definitions *for* merging; defaults to `['_components']` element
+ * @returns the destSwagger object
+ */
+function mergeSwagger(destSwagger, srcSwagger, tags, components) {
+
+  if (srcSwagger) {
+    _.defaults(destSwagger,
+      _.cloneDeep(
+        _.omitBy(srcSwagger, (v, k) => k.startsWith('_'))
+      )
+    );
+  }
+
+  // add any tags defined if dne
+  if (tags === undefined) {
+    tags = _.get(srcSwagger, '_tags');
+  }
+  if (tags && _.isArray(tags)) {
+    let dtags = getOrSet(destSwagger, '_tags', []);
+    tags.map(tag => {
+      let existing = dtags.find(t => t.name == tag.name);
+      if (existing) {
+        _.defaults(existing, tag);
+      } else {
+        dtags.push(_.cloneDeep(tag));
+      }
+    });
+  }
+
+  // add any components defined
+  if (components === undefined) {
+    components = _.get(srcSwagger, '_components')
+  }
+  if (components) {
+    _.forEach(componentDefinitionReference, (_unused, refName) => {
+      _.forEach(components[refName], (v, k) => {
+        let existing = _.get(destSwagger, ['_components', refName, k]);
+        if (existing === undefined) _.set(destSwagger, ['_components', refName, k], _.cloneDeep(v));
+      });
+    });
+  }
+
+  return destSwagger;
+}
+
+/// Reference object used in `mergeSwagger()` above
+var componentDefinitionReference = {
+  // Reusable schemas (data models)
+  schemas: {},
+  // Reusable path, query, header and cookie parameters
+  parameters: {},
+  // Security scheme definitions (see Authentication)
+  securitySchemes: {},
+  // Reusable request bodies
+  requestBodies: {},
+  // Reusable responses, such as 401 Unauthorized or 400 Bad Request
+  responses: {},
+  // Reusable response headers
+  headers: {},
+  // Reusable examples
+  examples: {},
+  // Reusable links
+  links: {},
+  // Reusable callbacks
+  callbacks: {},
+};
 
 module.exports = {
-    attributes: _parseAttributes,
-    routes: _parseRoutes
+  parseModels: parseModels,
+  parseCustomRoutes: parseCustomRoutes,
+  parseAllRoutes: parseAllRoutes,
+  mergeCustomAndAllRoutes: mergeCustomAndAllRoutes,
 };

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -18,7 +18,8 @@ function _parseAttributes(attributes) {
     var required = [];
     _.forEach(attributes, function (attribute, name) {
         var property = {};
-        property[name] = _.clone(formatters.attribute_type(attribute.type));//dereference our object here
+        let columnType = attribute.autoMigrations ? attribute.autoMigrations.columnType : undefined;
+        property[name] = _.clone(formatters.attribute_type(attribute.type, columnType));//dereference our object here
 
         //filter out required fields here
         if (_.has(attribute, 'required') && attribute.required === true)

--- a/lib/swaggerDoc.js
+++ b/lib/swaggerDoc.js
@@ -14,7 +14,25 @@ module.exports = function (sails, context) {
     specifications.parameters = generators.parameters(sails.config, context);
 
 
-    var generatedRoutes = generators.routes(sails.controllers, sails.config, specifications.tags);
+    let actions = sails.getActions();
+    let controllers = {};
+
+    _.each(actions, (action,path) => {
+      let [ identity, actionVerb ] = path.split('/');
+      let isBlueprint = action._middlewareType.startsWith('BLUEPRINT: ');
+      if(!isBlueprint) return;
+      if(!controllers[identity]) controllers[identity] = {};
+      controllers[identity][actionVerb] = {
+        http_method: action.http_method || 'get', //as my default
+        path: path, // action.path || (identity + '/' + action),
+        action: actionVerb,
+        keys: [], //always empty since they are directly from the controller file and not specified unless default blue prints
+        summary: action.summary,
+        description: action.description
+      };
+    });
+
+    var generatedRoutes = generators.routes(controllers, sails.config, specifications.tags);
     specifications.paths = generators.paths(generatedRoutes, specifications.tags, sails.config[context.configKey].blueprint_parameters);
 
 

--- a/lib/swaggerDoc.js
+++ b/lib/swaggerDoc.js
@@ -1,58 +1,74 @@
 'use strict';
-var _ = require('lodash');
-var generators = require('./generators');
-var fs = require('fs');
 
-module.exports = function (sails, context) {
-    if (sails.config[context.configKey].disabled === true) {
-        return;
-    }
+const _ = require('lodash');
+const fs = require('fs');
 
-    var specifications = sails.config[context.configKey].swagger;
-    specifications.tags = generators.tags(sails.models);
-    specifications.definitions = generators.definitions(sails.models);
-    specifications.parameters = generators.parameters(sails.config, context);
+const parsers = require('./parsers');
+const generators = require('./generators');
+const formatters = require("./type-formatter");
 
+module.exports = function (sails, sailsRoutes, context) {
 
-    let actions = sails.getActions();
-    let controllers = {};
+  let hookConfig = sails.config[context.configKey];
 
-    _.each(actions, (action,path) => {
-      let [ identity, actionVerb ] = path.split('/');
-      let isBlueprint = action._middlewareType.startsWith('BLUEPRINT: ');
-      if(!isBlueprint) return;
-      if(!controllers[identity]) controllers[identity] = {};
-      controllers[identity][actionVerb] = {
-        http_method: action.http_method || 'get', //as my default
-        path: path, // action.path || (identity + '/' + action),
-        action: actionVerb,
-        keys: [], //always empty since they are directly from the controller file and not specified unless default blue prints
-        summary: action.summary,
-        description: action.description
-      };
+  if (hookConfig.disabled === true) {
+    return;
+  }
+
+  let blueprintActionTemplates = _.cloneDeep(formatters.blueprintActionTemplates);
+  if (hookConfig.updateBlueprintActionTemplates) {
+    hookConfig.updateBlueprintActionTemplates(blueprintActionTemplates);
+  }
+
+  let specifications = _.cloneDeep(hookConfig.swagger);
+
+  let defaults = hookConfig.defaults || formatters.defaults;
+
+  let models = parsers.parseModels(sails.config, sails.models);
+  let customRoutes = parsers.parseCustomRoutes(sails.config);
+  let allRoutes = parsers.parseAllRoutes(sailsRoutes, models, sails.config);
+
+  // remove globally excluded routes
+  allRoutes = allRoutes.filter(r => {
+    if (r.path == '/__getcookie') return false;
+    return true;
+  });
+
+  let routes = parsers.mergeCustomAndAllRoutes(customRoutes, allRoutes);
+
+  if (hookConfig.includeRoute) {
+    routes = routes.filter(r => hookConfig.includeRoute(r));
+  }
+
+  if (!specifications.tags) specifications.tags = [];
+  if (!specifications.components) specifications.components = {};
+
+  specifications.components.schemas = generators.generateSchemas(models);
+
+  specifications.paths = generators.generatePaths(routes, blueprintActionTemplates, defaults, specifications.tags, specifications.components);
+
+  _.defaults(specifications.components.parameters, formatters.blueprintParameterTemplates);
+
+  // clean up of specification, removing unreferenced tags
+  let referencedTags = new Set();
+  _.forEach(specifications.paths, (pathDef, path) => {
+    _.forEach(pathDef, (def, httpMethod) => {
+      if (def.tags) def.tags.map(tag => referencedTags.add(tag))
     });
+  });
+  specifications.tags = specifications.tags.filter(tag => referencedTags.has(tag.name));
 
-    var generatedRoutes = generators.routes(controllers, sails.config, specifications.tags);
-    specifications.paths = generators.paths(generatedRoutes, specifications.tags, sails.config[context.configKey].blueprint_parameters);
+  if (hookConfig.postProcess) hookConfig.postProcess(specifications);
 
+  let destPath = sails.config[context.configKey].swaggerJsonPath;
+  try {
+    fs.writeFileSync(destPath, JSON.stringify(specifications, null, 2));
+  } catch(e) {
+    sails.log.error(`ERROR: sails-hook-swagger-generator: Error writing ${destPath}: ${e.message}`, e);
+  }
 
-    /**
-     * clean up of specification
-     * removing unwanted params
-     */
-    specifications.tags = _.map(specifications.tags, function (tag) {
-        delete tag.identity;
-        return tag;
-    });
+  sails.log.info('Swagger generated successfully');
 
-    fs.writeFile(sails.config[context.configKey].swaggerJsonPath, JSON.stringify(specifications), function (err) {
-        if (err) {
-            return console.log(err);
-        }
-
-        console.log("Swagger generated successfully");
-    });
-
-    return specifications;
+  return specifications;
 
 };

--- a/lib/type-formatter.js
+++ b/lib/type-formatter.js
@@ -3,114 +3,286 @@
  *
  * this modules helps us to stick with swagger specifications for formatting types
  */
-_ = require('lodash');
 
 /**
  * this is used to map our sails types with the allowed type defintions based on swagger specification
  * @type {{integer: {common_name: string, type: string, format: string, comments: string}, long: {common_name: string, type: string, format: string, comments: string}, float: {common_name: string, type: string, format: string}, double: {common_name: string, type: string, format: string}, string: {common_name: string, type: string}, byte: {common_name: string, type: string, format: string, comments: string}, binary: {common_name: string, type: string, format: string, comments: string}, boolean: {common_name: string, type: string}, date: {common_name: string, type: string, format: string, comments: string}, datetime: {common_name: string, type: string, format: string, comments: string}, password: {common_name: string, type: string, format: string, comments: string}}}
  */
-var swagger_types = {
-    integer: {common_name: 'integer', type: 'integer', format: 'int32', comments: 'signed 32 bits'},
-    long: {common_name: 'long', type: 'integer', format: 'int64', comments: 'signed 64 bits'},
-    float: {common_name: 'float', type: 'number', format: 'float'},
-    double: {common_name: 'double', type: 'number', format: 'double'},
-    string: {common_name: 'string', type: 'string'},
-    byte: {common_name: 'byte', type: 'string', format: 'byte', comments: 'base64 encoded characters'},
-    binary: {common_name: 'binary', type: 'string', format: 'binary', comments: 'any sequence of octets'},
-    boolean: {common_name: 'boolean', type: 'boolean'},
-    date: {common_name: 'date', type: 'string', format: 'date', comments: 'As defined by full-date - RFC3339'},
-    datetime: {
-        common_name: 'dateTime',
-        type: 'string',
-        format: 'date-time',
-        comments: 'As defined by date-time - RFC3339'
-    },
-    password: {common_name: 'password', type: 'string', format: 'password', comments: 'A hint to UIs to obscure input'}
+var swaggerTypes = {
+  integer: { common_name: 'integer', type: 'integer', format: 'int32', /* comments: 'signed 32 bits' */ },
+  long: { common_name: 'long', type: 'integer', format: 'int64', /* comments: 'signed 64 bits' */ },
+  float: { common_name: 'float', type: 'number', format: 'float' },
+  double: { common_name: 'double', type: 'number', format: 'double' },
+  string: { common_name: 'string', type: 'string' },
+  byte: { common_name: 'byte', type: 'string', format: 'byte', /* comments: 'base64 encoded characters' */ },
+  binary: { common_name: 'binary', type: 'string', format: 'binary', /* comments: 'any sequence of octets' */ },
+  boolean: { common_name: 'boolean', type: 'boolean' },
+  date: { common_name: 'date', type: 'string', format: 'date', /* comments: 'As defined by full-date - RFC3339' */ },
+  datetime: {
+    common_name: 'dateTime',
+    type: 'string',
+    format: 'date-time',
+    /* comments: 'As defined by date-time - RFC3339' */
+  },
+  password: { common_name: 'password', type: 'string', format: 'password', /* comments: 'A hint to UIs to obscure input' */ }
+};
+
+/**
+ * Defines allowed Sails model attribute definition values, and provides mapping to Swagger/OpenAPI names
+ */
+var sailAttributePropertiesMap = {
+  allowNull: 'nullable',
+  defaultsTo: 'default',
+  description: 'description',
+  externalDocs: 'externalDocs',
+  example: 'example',
 };
 
 /**
  * this is used to hold on to the different types of validation sails offers with the value as the swagger specification
- * @type {{max: string, min: string, maxLength: string, minLength: string, regex: string, required: string, enum: string}}
+ * @type {{max: string, min: string, maxLength: string, minLength: string, regex: string, isIn: string}}
  */
 var validationsMap = {
-    max: 'maximum',
-    min: 'minimum',
-    maxLength: 'maxLength',
-    minLength: 'minLength',
-    regex: 'pattern',
-    enum: 'enum',
-    items: 'items'
+  max: 'maximum',
+  min: 'minimum',
+  maxLength: 'maxLength',
+  minLength: 'minLength',
+  regex: 'pattern',
+  isIn: 'enum'
 };
 
 /**
- * this is used to bind our blueprint actions with our type of parameters
- * and custom map of which action to watch for and the param to attach to it
- * @type {{findOne: [*], find: [*], create: [*], update: [*], destroy: [*]}}
+ * Defines template for generating Swagger for each Sails blueprint action routes.
+ *
+ * In summary/description strings the value `{globalId}` is replaced with the applicable Sails model.
+ *
+ * Parameters values are Swagger definitions, with the exception of the string value
+ * `primaryKeyPathParameter` used to include a reference to a model's primary key (this is
+ * handled in `generatePaths()`).
+ *
+ * Modifiers are used to apply custom changes to the generated Swagger:
+ * - String values are predefined in `generatePaths()`
+ * - Functions are called with `func(blueprintActionTemplate, routeInfo, pathEntry)`
+ *
+ * These templates may be modfied / added to using the `updateBlueprintActionTemplates` config option
+ * e.g. to support custom blueprint actions/routes.
  */
-var blueprint_paramMap = {
-    findOne: [
-        {$ref: '#/parameters/TokenHeaderParam'},
-        {$ref: '#/parameters/IDPathParam'}
+var blueprintActionTemplates = {
+  findone: {
+    summary: 'Get {globalId} (find one)',
+    description: 'Look up the **{globalId}** record with the specified ID.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/find-one',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/find-one'
+    },
+    parameters: [
+      'primaryKeyPathParameter', // special case; filtered and substituted during generation phase
     ],
-    find: [
-        {$ref: '#/parameters/TokenHeaderParam'},
-        {$ref: '#/parameters/WhereQueryParam'},
-        {$ref: '#/parameters/LimitQueryParam'},
-        {$ref: '#/parameters/SkipQueryParam'},
-        {$ref: '#/parameters/SortQueryParam'},
-        {$ref: '#/parameters/PopulateQueryParam'},
-        {$ref: '#/parameters/SelectQueryParam'},
-        {$ref: '#/parameters/PageQueryParam'}],
-    create: [{$ref: '#/parameters/TokenHeaderParam'}],
-    update: [
-        {$ref: '#/parameters/TokenHeaderParam'},
-        {$ref: '#/parameters/IDPathParam'}],
-    destroy: [
-        {$ref: '#/parameters/TokenHeaderParam'},
-        {$ref: '#/parameters/IDPathParam'}]
+    resultDescription: 'Responds with a single **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Response denoting **{globalId}** record with specified ID **NOT** found',
+    // if functions, each called with (blueprintActionTemplate, routeInfo, pathEntry)
+    modifiers: ['addSelectQueryParam', 'addOmitQueryParam', 'addPopulateQueryParam', 'addResultOfModel', 'addResultNotFound'],
+  },
+  find: {
+    summary: 'List {globalId} (find where)',
+    description: 'Find a list of **{globalId}** records that match the specified criteria.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/find-where',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/find-where'
+    },
+    parameters: [
+      { $ref: '#/components/parameters/AttributeFilterParam' },
+      { $ref: '#/components/parameters/WhereQueryParam' },
+      { $ref: '#/components/parameters/LimitQueryParam' },
+      { $ref: '#/components/parameters/SkipQueryParam' },
+      { $ref: '#/components/parameters/SortQueryParam' },
+    ],
+    resultDescription: 'Responds with a paged list of **{globalId}** records that match the specified criteria',
+    modifiers: ['addSelectQueryParam', 'addOmitQueryParam', 'addPopulateQueryParam', 'addResultOfArrayOfModels'],
+  },
+  create: {
+    summary: 'Create {globalId}',
+    description: 'Create a new **{globalId}** record.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/create',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/create'
+    },
+    parameters: [],
+    resultDescription: 'Responds with a JSON dictionary representing the newly created **{globalId}** instance',
+    modifiers: ['addModelBodyParam', 'addResultOfModel', 'addResultValidationError'],
+  },
+  update: {
+    summary: 'Update {globalId}',
+    description: 'Update an existing **{globalId}** record.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/update',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/update'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+    ],
+    resultDescription: 'Responds with the newly updated **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Cannot update, **{globalId}** record with specified ID **NOT** found',
+    modifiers: ['addModelBodyParam', 'addResultOfModel', 'addResultValidationError', 'addResultNotFound'],
+  },
+  destroy: {
+    summary: 'Delete {globalId} (destroy)',
+    description: 'Delete the **{globalId}** record with the specified ID.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/destroy',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/destroy'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+    ],
+    resultDescription: 'Responds with a JSON dictionary representing the destroyed **{globalId}** instance',
+    notFoundDescription: 'Cannot destroy, **{globalId}** record with specified ID **NOT** found',
+    modifiers: ['addResultOfModel', 'addResultNotFound'],
+  },
+  populate: {
+    summary: 'Populate association for {globalId}',
+    description: 'Populate and return foreign record(s) for the given association of this **{globalId}** record.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/populate-where',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/populate-where'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+      { $ref: '#/components/parameters/WhereQueryParam' },
+      { $ref: '#/components/parameters/LimitQueryParam' },
+      { $ref: '#/components/parameters/SkipQueryParam' },
+      { $ref: '#/components/parameters/SortQueryParam' },
+    ],
+    resultDescription: 'Responds with the list of associated records as JSON dictionaries',
+    notFoundDescription: 'Cannot populate, **{globalId}** record with specified ID **NOT** found',
+    modifiers: ['addAssociationPathParam', 'addSelectQueryParam', 'addOmitQueryParam', 'addAssociationResultOfArray', 'addResultNotFound'],
+  },
+  add: {
+    summary: 'Add to for {globalId}',
+    description: 'Add a foreign record to one of this **{globalId}** record\'s collections.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/add-to',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/add-to'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+    ],
+    resultDescription: 'Responds with the newly updated **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Cannot perform add to, **{globalId}** record OR **FK record** with specified ID **NOT** found',
+    modifiers: ['addAssociationPathParam', 'addAssociationFKPathParam', 'addResultOfModel', 'addResultNotFound'],
+  },
+  remove: {
+    summary: 'Remove from for {globalId}',
+    description: 'Remove a foreign record from one of this **{globalId}** record\'s collections.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/remove-from',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/remove-from'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+    ],
+    resultDescription: 'Responds with the newly updated **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Cannot perform remove from, **{globalId}** record OR **FK record** with specified ID **NOT** found',
+    modifiers: ['addAssociationPathParam', 'addAssociationFKPathParam', 'addResultOfModel', 'addResultNotFound'],
+  },
+  replace: {
+    summary: 'Replace for {globalId}',
+    description: 'Replace all of the foreign **{globalId}** records in one of this record\'s collections.',
+    externalDocs: {
+      url: 'https://sailsjs.com/documentation/reference/blueprint-api/replace',
+      description: 'See https://sailsjs.com/documentation/reference/blueprint-api/replace'
+    },
+    parameters: [
+      'primaryKeyPathParameter',
+    ],
+    resultDescription: 'Responds with the newly updated **{globalId}** record as a JSON dictionary',
+    notFoundDescription: 'Cannot replace, **{globalId}** record with specified ID **NOT** found',
+    modifiers: ['addAssociationPathParam', 'addFksBodyParam', 'addResultOfModel', 'addResultNotFound'],
+  },
 };
 
+/**
+ * Defines standard parameters for generated Swagger for each Sails blueprint action routes.
+ */
+var blueprintParameterTemplates = {
+  AttributeFilterParam: {
+    in: 'query',
+    name: '_*_',
+    required: false,
+    schema: { type: 'string' },
+    description: 'To filter results based on a particular attribute, specify a query parameter with the same name'
+      + ' as the attribute defined on your model. For instance, if our `Purchase` model has an `amount` attribute, we'
+      + ' could send `GET /purchase?amount=99.99` to return a list of $99.99 purchases.',
+  },
+  WhereQueryParam: {
+    in: 'query',
+    name: 'where',
+    required: false,
+    schema: { type: 'string' },
+    description: 'Instead of filtering based on a specific attribute, you may instead choose to provide'
+      + ' a `where` parameter with the WHERE piece of a'
+      + ' [Waterline criteria](https://sailsjs.com/documentation/concepts/models-and-orm/query-language),'
+      + ' _encoded as a JSON string_. This allows you to take advantage of `contains`, `startsWith`, and'
+      + ' other sub-attribute criteria modifiers for more powerful `find()` queries.'
+      + '\n\ne.g. `?where={"name":{"contains":"theodore"}}`'
+  },
+  LimitQueryParam: {
+    in: 'query',
+    name: 'limit',
+    required: false,
+    schema: { type: 'integer' },
+    description: 'The maximum number of records to send back (useful for pagination). Defaults to 30.'
+  },
+  SkipQueryParam: {
+    in: 'query',
+    name: 'skip',
+    required: false,
+    schema: { type: 'integer' },
+    description: 'The number of records to skip (useful for pagination).'
+  },
+  SortQueryParam: {
+    in: 'query',
+    name: 'sort',
+    required: false,
+    schema: { type: 'string' },
+    description: 'The sort order. By default, returned records are sorted by primary key value in ascending order.'
+      + '\n\ne.g. `?sort=lastName%20ASC`'
+  },
+};
+
+/**
+ * Defines standard Sails responses as used within actions2 actions.
+ */
+var actions2Responses = {
+  success: { statusCode: '200', description: 'Success' },
+  badRequest: { statusCode: '400', description: 'Bad request' },
+  forbidden: { statusCode: '403', description: 'Forbidden' },
+  notFound: { statusCode: '404', description: 'Not found' },
+  error: { statusCode: '500', description: 'Server error' },
+};
+
+/**
+ * Default values for produces/consumes and responses for custom actions.
+ */
+let defaults = {
+  responses: {
+    '200': { description: 'The requested resource' },
+    '404': { description: 'Resource not found' },
+    '500': { description: 'Internal server error' }
+  }
+};
 
 module.exports = {
-    /**
-     * this returns the swagger specification types based on the common name parsed
-     * then removed anything asside type and format as they don't fit to swagger spec
-     * @param common_name
-     * @returns {*|swagger_types.string|{common_name, type}}
-     */
-    attribute_type: function (common_name, columnType) {
-        var type = swagger_types[common_name] || swagger_types.string;
-        if(common_name=='number') {
-          type = swagger_types.integer;
-        }
-        if(common_name=='ref' && columnType!==undefined) {
-          var mappedType = {
-            timestamp: swagger_types.datetime,
-            datetime: swagger_types.datetime,
-          }[columnType.toLowerCase()];
-          if(mappedType) type = mappedType;
-        }
-        delete type.common_name;
-        delete type.comments;
-        return type;
-    },
 
-    /**
-     * this returns the equivalent swagger specification for the passed sails validation rule
-     * @param rule
-     * @returns {*}
-     */
-    validation_type: function (rule) {
-        return validationsMap[rule];
-    },
-    /**
-     * this is used to return our params attached to each of our parameters created @link generators.parameters
-     * @param action
-     * @param customMaps this holds the custom maps created from our sails.config[configKey].blueprint_parameters
-     * @returns {*}
-     */
-    blueprint_parameter: function (action, customMaps) {
-        var map = _.defaults(customMaps, blueprint_paramMap); //override using the custom if it exist
-        return map[action];
-    }
+  swaggerTypes: swaggerTypes,
+  sailAttributePropertiesMap: sailAttributePropertiesMap,
+  validationsMap: validationsMap,
+
+  blueprintActionTemplates: blueprintActionTemplates,
+  blueprintParameterTemplates: blueprintParameterTemplates,
+
+  actions2Responses: actions2Responses,
+
+  defaults: defaults,
+
 };

--- a/lib/type-formatter.js
+++ b/lib/type-formatter.js
@@ -78,8 +78,18 @@ module.exports = {
      * @param common_name
      * @returns {*|swagger_types.string|{common_name, type}}
      */
-    attribute_type: function (common_name) {
+    attribute_type: function (common_name, columnType) {
         var type = swagger_types[common_name] || swagger_types.string;
+        if(common_name=='number') {
+          type = swagger_types.integer;
+        }
+        if(common_name=='ref' && columnType!==undefined) {
+          var mappedType = {
+            timestamp: swagger_types.datetime,
+            datetime: swagger_types.datetime,
+          }[columnType.toLowerCase()];
+          if(mappedType) type = mappedType;
+        }
         delete type.common_name;
         delete type.comments;
         return type;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,76 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@mapbox/geojsonhint": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojsonhint/-/geojsonhint-1.2.1.tgz",
-      "integrity": "sha1-Kv5DXo1WeqUYc+seG6ZcxNRjx6A=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.0",
-        "concat-stream": "~1.4.4",
-        "jsonlint-lines": "1.7.1",
-        "minimist": "1.1.1",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "concat-stream": {
-          "version": "1.4.10",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
-          "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
-          "dev": true,
-          "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~1.1.9",
-            "typedarray": "~0.0.5"
-          }
-        },
-        "minimist": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
-          "integrity": "sha1-G8K8cWWM3KVxJHVoQ2NhWwtPaVs=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "@sailshq/lodash": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.2.tgz",
-      "integrity": "sha1-FWfUc0U2TCwuIHe8ETSHsd/mIVQ=",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@sailshq/lodash/-/lodash-3.10.3.tgz",
+      "integrity": "sha512-XTF5BtsTSiSpTnfqrCGS5Q8FvSHWCywA0oRxFAZo8E1a8k1MMFUvk3VlRk3q/SusEYwy7gvVdyt9vvNlTa2VuA==",
       "dev": true
     },
     "@semantic-release/commit-analyzer": {
@@ -363,12 +297,6 @@
         "through": ">=2.2.7 <3"
       }
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -376,20 +304,14 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
-      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.6",
-        "negotiator": "0.5.3"
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
       }
-    },
-    "after": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
-      "integrity": "sha1-q11PuIP1loFtNRX495HAr0ht1ic=",
-      "dev": true
     },
     "agent-base": {
       "version": "2.1.1",
@@ -421,198 +343,14 @@
         "uri-js": "^4.2.2"
       }
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
-    },
     "anchor": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/anchor/-/anchor-0.10.5.tgz",
-      "integrity": "sha1-H54EMjowh/q53ufYilEJm35fsLU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/anchor/-/anchor-1.4.0.tgz",
+      "integrity": "sha512-xEu0UWxNa3p5v3MmXN9id5tsMSiniCyzWamf/R3KRkJieSRdXdAWu0Z+tXIpDZbbVLWZSMnD1VEguuYX2s9xag==",
       "dev": true,
       "requires": {
-        "geojsonhint": "^1.1.0",
-        "lodash": "~3.9.3",
-        "validator": "~3.41.2"
-      },
-      "dependencies": {
-        "geojsonhint": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "colors": "~0.6.0-1",
-            "concat-stream": "~1.4.4",
-            "jsonlint-lines": "~1.6.0",
-            "minimist": "1.1.1",
-            "optimist": "~0.6.0"
-          },
-          "dependencies": {
-            "colors": {
-              "version": "0.6.2",
-              "bundled": true,
-              "dev": true
-            },
-            "concat-stream": {
-              "version": "1.4.10",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "inherits": "~2.0.1",
-                "readable-stream": "~1.1.9",
-                "typedarray": "~0.0.5"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "1.1.13",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.1",
-                    "isarray": "0.0.1",
-                    "string_decoder": "~0.10.x"
-                  },
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "bundled": true,
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "jsonlint-lines": {
-              "version": "1.6.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "JSV": ">= 4.0.x",
-                "nomnom": ">= 1.5.x"
-              },
-              "dependencies": {
-                "JSV": {
-                  "version": "4.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "nomnom": {
-                  "version": "1.8.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "chalk": "~0.4.0",
-                    "underscore": "~1.6.0"
-                  },
-                  "dependencies": {
-                    "chalk": {
-                      "version": "0.4.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-styles": "~1.0.0",
-                        "has-color": "~0.1.0",
-                        "strip-ansi": "~0.1.0"
-                      },
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "has-color": {
-                          "version": "0.1.7",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "strip-ansi": {
-                          "version": "0.1.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "underscore": {
-                      "version": "1.6.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "bundled": true,
-                  "dev": true
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "bundled": true,
-          "dev": true
-        },
-        "validator": {
-          "version": "3.41.2",
-          "bundled": true,
-          "dev": true
-        }
+        "@sailshq/lodash": "^3.10.2",
+        "validator": "5.7.0"
       }
     },
     "ansi": {
@@ -670,9 +408,9 @@
       "dev": true
     },
     "ansi-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "aproba": {
@@ -730,19 +468,18 @@
       }
     },
     "argparse": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-      "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "underscore": "~1.7.0",
-        "underscore.string": "~2.4.0"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
-        "underscore.string": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-          "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs=",
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
           "dev": true
         }
       }
@@ -753,16 +490,16 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
-      "dev": true
-    },
-    "arraybuffer.slice": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-      "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
       "dev": true
     },
     "arrify": {
@@ -771,26 +508,6 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
-    "asap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
-      "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0=",
-      "dev": true
-    },
-    "asn1": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
-      "dev": true,
-      "optional": true
-    },
-    "assert-plus": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
-      "dev": true,
-      "optional": true
-    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
@@ -798,23 +515,19 @@
       "dev": true
     },
     "async": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-      "dev": true
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.14.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
-      "integrity": "sha1-xXED96F/wDfwLXwuZLYC6iI/fWM=",
-      "dev": true,
-      "optional": true
     },
     "aws4": {
       "version": "1.8.0",
@@ -1529,52 +1242,10 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
-    "backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "base64-arraybuffer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
-      "integrity": "sha1-R030qfLaJOBd8xWMOx2zw81GoVQ=",
-      "dev": true
-    },
-    "base64-url": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz",
-      "integrity": "sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg=",
-      "dev": true
-    },
-    "base64id": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
-      "integrity": "sha1-As4P3u4M709ACA4ec+g08LG/zj8=",
-      "dev": true
-    },
-    "basic-auth": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.4.tgz",
-      "integrity": "sha1-Awk1sB3nyblKgksp8/zLdQ06UpA=",
-      "dev": true
-    },
-    "basic-auth-connect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz",
-      "integrity": "sha1-/bC0OWLKe0BFanwrtI/hc9otISI=",
-      "dev": true
-    },
-    "batch": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-      "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
       "dev": true
     },
     "bcrypt-pbkdf": {
@@ -1586,82 +1257,72 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "benchmark": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-      "integrity": "sha1-Lx4vpMNZ8REiqhgwgiGOlX45DHM=",
-      "dev": true
-    },
-    "better-assert": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+    "binary-search-tree": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
+      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
       "dev": true,
       "requires": {
-        "callsite": "1.0.0"
+        "underscore": "~1.4.4"
       }
     },
-    "blob": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-      "dev": true
-    },
     "bluebird": {
-      "version": "2.9.34",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz",
-      "integrity": "sha1-L3tOyAIWMoqf3evfacjUlC/v99g=",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.2.1.tgz",
+      "integrity": "sha1-POzzUEkEwwzj55wXCHfok6EZEP0=",
       "dev": true
     },
     "body-parser": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
-      "integrity": "sha1-wIzzMMM1jhUQFqBXRvE/ApyX+pc=",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "dev": true,
       "requires": {
-        "bytes": "2.1.0",
-        "content-type": "~1.0.1",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "http-errors": "~1.3.1",
-        "iconv-lite": "0.4.11",
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
         "on-finished": "~2.3.0",
-        "qs": "4.0.0",
-        "raw-body": "~2.1.2",
-        "type-is": "~1.6.6"
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
-        "qs": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
-      }
-    },
-    "boom": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
       }
     },
     "boxen": {
@@ -1780,9 +1441,9 @@
       }
     },
     "bytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz",
-      "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cacheable-request": {
@@ -1808,10 +1469,10 @@
         }
       }
     },
-    "callsite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
       "dev": true
     },
     "camelcase": {
@@ -1845,33 +1506,41 @@
       "dev": true
     },
     "captains-log": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/captains-log/-/captains-log-0.11.11.tgz",
-      "integrity": "sha1-live/UQ1HDBrAMRabalhSsNYU4w=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/captains-log/-/captains-log-2.0.2.tgz",
+      "integrity": "sha512-1Epy1ERBPqAX6a2V2tZkKlwMvzUrGznCALk6bBNZ+KKLBLzY9bfMYhcRuNuCvpbmRflLv+N/Z0PMctcqEgJrqg==",
       "dev": true,
       "requires": {
-        "colors": "~0.6.2",
-        "lodash": "2.4.1",
-        "merge-defaults": "~0.1.0",
-        "rc": "~0.3.2"
+        "@sailshq/lodash": "^3.10.2",
+        "chalk": "1.1.3",
+        "rc": "1.2.8",
+        "semver": "5.4.1"
       },
       "dependencies": {
-        "lodash": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
-          "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
-          "dev": true
-        },
-        "rc": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.3.5.tgz",
-          "integrity": "sha1-/OIiBZO+V6oSlmhafjftAD38xyg=",
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "deep-extend": "~0.2.5",
-            "ini": "~1.1.0",
-            "minimist": "~0.0.7"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -1886,16 +1555,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chai": {
       "version": "4.1.1",
@@ -1912,14 +1571,40 @@
       }
     },
     "chalk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "~1.0.0",
-        "has-color": "~0.1.0",
-        "strip-ansi": "~0.1.0"
+        "ansi-styles": "^3.1.0",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
       }
     },
     "check-error": {
@@ -1934,47 +1619,11 @@
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
-    "clean-css": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.1.8.tgz",
-      "integrity": "sha1-K0sv1g8yRBCWIWriWiH6p0WA3IM=",
-      "dev": true,
-      "requires": {
-        "commander": "2.1.x"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-          "dev": true
-        }
-      }
-    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        }
-      }
     },
     "clone-response": {
       "version": "1.0.2",
@@ -1989,12 +1638,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "coffee-script": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz",
-      "integrity": "sha1-FQ1rTLUiiUNp7+1qIQHCC8f0pPQ=",
       "dev": true
     },
     "color-convert": {
@@ -2018,16 +1661,6 @@
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
     },
-    "combined-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-      "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delayed-stream": "0.0.5"
-      }
-    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
@@ -2036,6 +1669,12 @@
       "requires": {
         "graceful-readlink": ">= 1.0.0"
       }
+    },
+    "common-js-file-extensions": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/common-js-file-extensions/-/common-js-file-extensions-1.0.2.tgz",
+      "integrity": "sha1-Hs8ThwARVtpoD1gUmovpvrgEvx4=",
+      "dev": true
     },
     "compare-func": {
       "version": "1.3.2",
@@ -2047,61 +1686,38 @@
         "dot-prop": "^3.0.0"
       }
     },
-    "component-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-      "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
-      "dev": true
-    },
-    "component-inherit": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
-      "dev": true
-    },
     "compressible": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
-      "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "dev": true,
       "requires": {
-        "mime-db": ">= 1.29.0 < 2"
+        "mime-db": ">= 1.40.0 < 2"
       }
     },
     "compression": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz",
-      "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "dev": true,
       "requires": {
-        "accepts": "~1.2.12",
-        "bytes": "2.1.0",
-        "compressible": "~2.0.5",
-        "debug": "~2.2.0",
-        "on-headers": "~1.0.0",
-        "vary": "~1.0.1"
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.11",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -2204,99 +1820,25 @@
       }
     },
     "connect": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.0.tgz",
-      "integrity": "sha1-ocM/RNBQIaSl2VpgAhcLqsnM8P8=",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
+      "integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
       "dev": true,
       "requires": {
-        "basic-auth-connect": "1.0.0",
-        "body-parser": "~1.13.1",
-        "bytes": "2.1.0",
-        "compression": "~1.5.0",
-        "connect-timeout": "~1.6.2",
-        "content-type": "~1.0.1",
-        "cookie": "0.1.3",
-        "cookie-parser": "~1.3.5",
-        "cookie-signature": "1.0.6",
-        "csurf": "~1.8.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "errorhandler": "~1.4.0",
-        "express-session": "~1.11.3",
-        "finalhandler": "0.4.0",
-        "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
-        "method-override": "~2.3.3",
-        "morgan": "~1.6.0",
-        "multiparty": "3.3.2",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
-        "pause": "0.0.1",
-        "qs": "2.4.2",
-        "response-time": "~2.3.1",
-        "serve-favicon": "~2.3.0",
-        "serve-index": "~1.7.0",
-        "serve-static": "~1.10.0",
-        "type-is": "~1.6.3",
-        "utils-merge": "1.0.0",
-        "vhost": "~3.0.0"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "connect-flash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
-      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA=",
-      "dev": true
-    },
-    "connect-timeout": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.6.2.tgz",
-      "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
-      "dev": true,
-      "requires": {
-        "debug": "~2.2.0",
-        "http-errors": "~1.3.1",
-        "ms": "0.7.1",
-        "on-headers": "~1.0.0"
+        "debug": "2.6.9",
+        "finalhandler": "1.0.6",
+        "parseurl": "~1.3.2",
+        "utils-merge": "1.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -2307,15 +1849,15 @@
       "dev": true
     },
     "content-disposition": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz",
-      "integrity": "sha1-QoT+auBjCHRjnkToCkGMKTQTXp4=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "conventional-changelog": {
@@ -2737,34 +2279,20 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "convert-to-ecmascript-compatible-varname": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/convert-to-ecmascript-compatible-varname/-/convert-to-ecmascript-compatible-varname-0.1.5.tgz",
-      "integrity": "sha1-9npJOMUjNENWQlBHnGcBS6yHhJk=",
-      "dev": true
-    },
     "cookie": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz",
-      "integrity": "sha1-cv7D0k5Io0Mgc9kMEmQgBQYQBLE=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
     "cookie-parser": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
-      "integrity": "sha1-nXVVcPtdF4kHcSJ6AjFNm+fPg1Y=",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=",
       "dev": true,
       "requires": {
-        "cookie": "0.1.3",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        }
       }
     },
     "cookie-signature": {
@@ -2786,9 +2314,9 @@
       "dev": true
     },
     "crc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
-      "integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo=",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
+      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms=",
       "dev": true
     },
     "create-error-class": {
@@ -2830,47 +2358,6 @@
         }
       }
     },
-    "cross-spawn-async": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^4.0.0",
-        "which": "^1.2.8"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "which": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
-    },
-    "cryptiles": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x"
-      }
-    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -2900,31 +2387,16 @@
       }
     },
     "csurf": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
-      "integrity": "sha1-I/KhO/HY/OHQyZZYg5RELLqGpWo=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.9.0.tgz",
+      "integrity": "sha1-SdLGkl/87Ht95VlZfBU/pTM2QTM=",
       "dev": true,
       "requires": {
-        "cookie": "0.1.3",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "csrf": "~3.0.0",
-        "http-errors": "~1.3.1"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        }
+        "csrf": "~3.0.3",
+        "http-errors": "~1.5.0"
       }
-    },
-    "ctype": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
-      "dev": true,
-      "optional": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -2967,12 +2439,6 @@
         }
       }
     },
-    "dateformat": {
-      "version": "1.0.2-1.2.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
-      "integrity": "sha1-sCIMAt6YYXQztyhRz0fePfLNvuk=",
-      "dev": true
-    },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
@@ -3013,12 +2479,6 @@
         "mimic-response": "^1.0.0"
       }
     },
-    "deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
-      "dev": true
-    },
     "deep-eql": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
@@ -3037,29 +2497,16 @@
       }
     },
     "deep-equal": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz",
-      "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-extend": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-      "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
-    },
-    "defined": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
-      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
-      "dev": true
-    },
-    "delayed-stream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-      "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
-      "dev": true,
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -3068,9 +2515,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
-      "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
@@ -3112,11 +2559,14 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "dot-access": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dot-access/-/dot-access-1.0.0.tgz",
-      "integrity": "sha1-o2LlolkGtVurSKQtEBU4cmBh+mg=",
-      "dev": true
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "dot-prop": {
       "version": "3.0.0",
@@ -3126,6 +2576,12 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -3156,19 +2612,10 @@
       "dev": true
     },
     "ejs": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-0.8.8.tgz",
-      "integrity": "sha1-/9xW3MNdApJt1QrRNDm7xUBh1Zg=",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.7.tgz",
+      "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo=",
       "dev": true
-    },
-    "ejs-locals": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ejs-locals/-/ejs-locals-1.0.2.tgz",
-      "integrity": "sha1-ubMg/2kzFUEF+g7taD6mTWeAiM4=",
-      "dev": true,
-      "requires": {
-        "ejs": "0.8.x"
-      }
     },
     "electron-to-chromium": {
       "version": "1.3.122",
@@ -3176,137 +2623,19 @@
       "integrity": "sha512-3RKoIyCN4DhP2dsmleuFvpJAIDOseWH88wFYBzb22CSwoFDSWRc4UAMfrtc9h8nBdJjTNIN3rogChgOy6eFInw==",
       "dev": true
     },
-    "engine.io": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
-      "integrity": "sha1-JTOpemWHbED/z5U5e375tJXEI/4=",
-      "dev": true,
-      "requires": {
-        "accepts": "1.1.4",
-        "base64id": "0.1.0",
-        "debug": "2.2.0",
-        "engine.io-parser": "1.2.4",
-        "ws": "1.1.0"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
-          "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
-          "dev": true,
-          "requires": {
-            "mime-types": "~2.0.4",
-            "negotiator": "0.4.9"
-          }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "mime-db": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
-          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true,
-          "requires": {
-            "mime-db": "~1.12.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.4.9",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
-          "integrity": "sha1-kuRrbbU8fkIe1koryU8IvnYw3z8=",
-          "dev": true
-        }
-      }
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
-    "engine.io-client": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
-      "integrity": "sha1-fSUNj6HCGBGezeUTkEWKV9UXE3Y=",
+    "encrypted-attr": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/encrypted-attr/-/encrypted-attr-1.0.6.tgz",
+      "integrity": "sha512-12WE8GDkbhKcGmVp6+TyJXCcFj9NF7db33nutjOSBLlMuYY4oCGricgTEUAuRSI1xLeE1nhoDD6jSx20WgFVYg==",
       "dev": true,
       "requires": {
-        "component-emitter": "1.1.2",
-        "component-inherit": "0.0.3",
-        "debug": "2.2.0",
-        "engine.io-parser": "1.2.4",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.1",
-        "parseqs": "0.0.2",
-        "parseuri": "0.0.4",
-        "ws": "1.0.1",
-        "xmlhttprequest-ssl": "1.5.1",
-        "yeast": "0.1.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "ws": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
-          "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
-          "dev": true,
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        }
-      }
-    },
-    "engine.io-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
-      "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
-      "dev": true,
-      "requires": {
-        "after": "0.8.1",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.2",
-        "blob": "0.0.4",
-        "has-binary": "0.1.6",
-        "utf8": "2.1.0"
-      },
-      "dependencies": {
-        "has-binary": {
-          "version": "0.1.6",
-          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
-          "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
+        "lodash": "^4.17.4"
       }
     },
     "error-ex": {
@@ -3316,34 +2645,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "errorhandler": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
-      "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
-      "dev": true,
-      "requires": {
-        "accepts": "~1.3.0",
-        "escape-html": "~1.0.3"
-      },
-      "dependencies": {
-        "accepts": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
-          "requires": {
-            "mime-types": "~2.1.11",
-            "negotiator": "0.6.1"
-          }
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
-        }
       }
     },
     "escape-html": {
@@ -3359,9 +2660,9 @@
       "dev": true
     },
     "esprima": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esutils": {
@@ -3371,9 +2672,9 @@
       "dev": true
     },
     "etag": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-stream": {
@@ -3391,12 +2692,6 @@
         "through": "^2.3.8"
       }
     },
-    "eventemitter2": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
-      "dev": true
-    },
     "execa": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
@@ -3412,232 +2707,106 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
     "express": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-3.21.2.tgz",
-      "integrity": "sha1-DCkD7lxU5j1lqWFwdkcDVQZlo94=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
-        "basic-auth": "~1.0.3",
-        "commander": "2.6.0",
-        "connect": "2.30.2",
-        "content-disposition": "0.5.0",
-        "content-type": "~1.0.1",
-        "cookie": "0.1.3",
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "escape-html": "1.0.2",
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "merge-descriptors": "1.0.0",
-        "methods": "~1.1.1",
-        "mkdirp": "0.5.1",
-        "parseurl": "~1.3.0",
-        "proxy-addr": "~1.0.8",
-        "range-parser": "~1.0.2",
-        "send": "0.13.0",
-        "utils-merge": "1.0.0",
-        "vary": "~1.0.1"
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-          "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0=",
-          "dev": true
-        },
-        "connect": {
-          "version": "2.30.2",
-          "resolved": "https://registry.npmjs.org/connect/-/connect-2.30.2.tgz",
-          "integrity": "sha1-jam8vooFTT0xjXTf7JA7XDmhtgk=",
-          "dev": true,
-          "requires": {
-            "basic-auth-connect": "1.0.0",
-            "body-parser": "~1.13.3",
-            "bytes": "2.1.0",
-            "compression": "~1.5.2",
-            "connect-timeout": "~1.6.2",
-            "content-type": "~1.0.1",
-            "cookie": "0.1.3",
-            "cookie-parser": "~1.3.5",
-            "cookie-signature": "1.0.6",
-            "csurf": "~1.8.3",
-            "debug": "~2.2.0",
-            "depd": "~1.0.1",
-            "errorhandler": "~1.4.2",
-            "express-session": "~1.11.3",
-            "finalhandler": "0.4.0",
-            "fresh": "0.3.0",
-            "http-errors": "~1.3.1",
-            "method-override": "~2.3.5",
-            "morgan": "~1.6.1",
-            "multiparty": "3.3.2",
-            "on-headers": "~1.0.0",
-            "parseurl": "~1.3.0",
-            "pause": "0.1.0",
-            "qs": "4.0.0",
-            "response-time": "~2.3.1",
-            "serve-favicon": "~2.3.0",
-            "serve-index": "~1.7.2",
-            "serve-static": "~1.10.0",
-            "type-is": "~1.6.6",
-            "utils-merge": "1.0.0",
-            "vhost": "~3.0.1"
-          }
-        },
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
-        "destroy": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz",
-          "integrity": "sha1-tDO0ck5x/YVR2YhRdIUcX8N34sk=",
-          "dev": true
-        },
-        "escape-html": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-          "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "pause": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/pause/-/pause-0.1.0.tgz",
-          "integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q=",
-          "dev": true
-        },
-        "qs": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
-          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
-          "dev": true
-        },
-        "send": {
-          "version": "0.13.0",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
-          "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
           "dev": true,
           "requires": {
-            "debug": "~2.2.0",
-            "depd": "~1.0.1",
-            "destroy": "1.0.3",
-            "escape-html": "1.0.2",
-            "etag": "~1.7.0",
-            "fresh": "0.3.0",
-            "http-errors": "~1.3.1",
-            "mime": "1.3.4",
-            "ms": "0.7.1",
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
             "on-finished": "~2.3.0",
-            "range-parser": "~1.0.2",
-            "statuses": "~1.2.1"
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
-        "statuses": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
           "dev": true
-        }
-      }
-    },
-    "express-handlebars": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-2.0.1.tgz",
-      "integrity": "sha1-l1Zh/+vW55RjIwukyODKXNBSL7E=",
-      "dev": true,
-      "requires": {
-        "glob": "^5.0.0",
-        "graceful-fs": "^3.0.2",
-        "handlebars": "^3.0.0",
-        "object.assign": "^1.1.1",
-        "promise": "^6.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
         }
       }
     },
     "express-session": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
-      "integrity": "sha1-XMmPP1/4Ttg1+Ry/CqvQxxB0AK8=",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
+      "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
       "dev": true,
       "requires": {
-        "cookie": "0.1.3",
+        "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "crc": "3.3.0",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-headers": "~1.0.0",
-        "parseurl": "~1.3.0",
-        "uid-safe": "~2.0.0",
-        "utils-merge": "1.0.0"
+        "crc": "3.4.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "on-headers": "~1.0.1",
+        "parseurl": "~1.3.2",
+        "uid-safe": "~2.1.5",
+        "utils-merge": "1.0.1"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz",
-          "integrity": "sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=",
-          "dev": true
-        },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "uid-safe": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
-          "integrity": "sha1-p/PGymSh9qXQTsDvPkw9U2cxcTc=",
-          "dev": true,
-          "requires": {
-            "base64-url": "1.2.1"
+            "ms": "2.0.0"
           }
         }
       }
@@ -3672,44 +2841,38 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
-    "faye-websocket": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
-      "integrity": "sha1-wUxbO/FNdBf/v9mQwKdJXNnzN7w=",
-      "dev": true
-    },
-    "finalhandler": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz",
-      "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "escape-html": "1.0.2",
+        "pend": "~1.2.0"
+      }
+    },
+    "finalhandler": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+      "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
-        },
-        "escape-html": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz",
-          "integrity": "sha1-130y+pjjjC9BroXpJ44ODmuhAiw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -3723,42 +2886,13 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "findup-sync": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-      "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+    "flaverr": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/flaverr/-/flaverr-1.10.0.tgz",
+      "integrity": "sha512-POaguCzNjWKEKsBkks4YGgNv1LVUqTX4MTudca5ArQAxtBrPswQLAW8la4Hbo0EZy9tpU3a9WwsKdAACqZnE/Q==",
       "dev": true,
       "requires": {
-        "glob": "~3.2.9",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
+        "@sailshq/lodash": "^3.10.2"
       }
     },
     "follow-redirects": {
@@ -3777,44 +2911,16 @@
       "integrity": "sha1-VQKYfchxS+M5IJfzLgBxyd7gfPY=",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
-      "dev": true,
-      "optional": true
-    },
-    "form-data": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-      "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async": "~0.9.0",
-        "combined-stream": "~0.0.4",
-        "mime": "~1.2.11"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fresh": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from": {
@@ -3872,23 +2978,16 @@
       }
     },
     "fs-extra": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.8.1.tgz",
-      "integrity": "sha1-Dld5/7/t9RG8dVWVx/A8BtS0Po0=",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "jsonfile": "~1.1.0",
-        "mkdirp": "0.3.x",
-        "ncp": "~0.4.2",
-        "rimraf": "~2.2.0"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        }
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -3922,15 +3021,6 @@
             "ansi-regex": "^2.0.0"
           }
         }
-      }
-    },
-    "gaze": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true,
-      "requires": {
-        "globule": "~0.1.0"
       }
     },
     "get-caller-file": {
@@ -3968,12 +3058,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
-    "getobject": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
-      "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
     },
     "getpass": {
@@ -4440,58 +3524,6 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globule": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-      "dev": true,
-      "requires": {
-        "glob": "~3.1.21",
-        "lodash": "~1.0.1",
-        "minimatch": "~0.2.11"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
-          }
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
-      }
-    },
     "got": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
@@ -4526,13 +3558,10 @@
       }
     },
     "graceful-fs": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-      "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-      "dev": true,
-      "requires": {
-        "natives": "^1.1.0"
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -4545,328 +3574,6 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
-    },
-    "grunt": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.2.tgz",
-      "integrity": "sha1-iVtPKKYQK//UHTZaZei+LWopPZM=",
-      "dev": true,
-      "requires": {
-        "async": "~0.1.22",
-        "coffee-script": "~1.3.3",
-        "colors": "~0.6.2",
-        "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "~0.4.13",
-        "exit": "~0.1.1",
-        "findup-sync": "~0.1.2",
-        "getobject": "~0.1.0",
-        "glob": "~3.1.21",
-        "hooker": "~0.2.3",
-        "iconv-lite": "~0.2.11",
-        "js-yaml": "~2.0.5",
-        "lodash": "~0.9.2",
-        "minimatch": "~0.2.12",
-        "nopt": "~1.0.10",
-        "rimraf": "~2.0.3",
-        "underscore.string": "~2.2.1",
-        "which": "~1.0.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
-          "integrity": "sha1-D8GqoIig4+8Ovi2IMbqw3PiEUGE=",
-          "dev": true
-        },
-        "glob": {
-          "version": "3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~1.2.0",
-            "inherits": "1",
-            "minimatch": "~0.2.11"
-          }
-        },
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz",
-          "integrity": "sha1-jzSZxSRdNG1oLlsNO0B2fgnxqSw=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "rimraf": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.0.3.tgz",
-          "integrity": "sha1-9QopZecUTpr9mYmC8V33BnMPVqk=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "~1.1"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz",
-              "integrity": "sha1-BweNtfY3f2Mh/Oqu30l94STclGU=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        }
-      }
-    },
-    "grunt-cli": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-0.1.13.tgz",
-      "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
-      "dev": true,
-      "requires": {
-        "findup-sync": "~0.1.0",
-        "nopt": "~1.0.10",
-        "resolve": "~0.3.1"
-      }
-    },
-    "grunt-contrib-clean": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.5.0.tgz",
-      "integrity": "sha1-9T397ghJsce0Dp67umn0jExgecU=",
-      "dev": true,
-      "requires": {
-        "rimraf": "~2.2.1"
-      }
-    },
-    "grunt-contrib-coffee": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-coffee/-/grunt-contrib-coffee-0.10.1.tgz",
-      "integrity": "sha1-7SLGgp9FiqjqR/hnaEM+mBMUAYY=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "coffee-script": "~1.7.0",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "coffee-script": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
-          "integrity": "sha1-YplqhheAx15tUGnROCJyO3NAS/w=",
-          "dev": true,
-          "requires": {
-            "mkdirp": "~0.3.5"
-          }
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-contrib-concat": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
-      "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
-      "dev": true
-    },
-    "grunt-contrib-copy": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
-      "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
-      "dev": true
-    },
-    "grunt-contrib-cssmin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-0.9.0.tgz",
-      "integrity": "sha1-JyQfAWCohmZZ2rQNyMJ3bAHsfOI=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "clean-css": "~2.1.0",
-        "maxmin": "~0.1.0"
-      }
-    },
-    "grunt-contrib-jst": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jst/-/grunt-contrib-jst-0.6.0.tgz",
-      "integrity": "sha1-tU1xrqNBzmZfMyqIy+ArehIYFks=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "grunt-lib-contrib": "~0.7.0",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-contrib-less": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-less/-/grunt-contrib-less-0.11.1.tgz",
-      "integrity": "sha1-BnFlTkkaXHg4k8K0lHHCSZKso04=",
-      "dev": true,
-      "requires": {
-        "async": "^0.2.10",
-        "chalk": "^0.4.0",
-        "less": "^1.7.0",
-        "lodash": "^2.4.1",
-        "maxmin": "^0.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-contrib-uglify": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-0.4.1.tgz",
-      "integrity": "sha1-1D87xuAsM1Vj+MT58IE/tLD/ebE=",
-      "dev": true,
-      "requires": {
-        "chalk": "^0.4.0",
-        "maxmin": "^0.1.0",
-        "uglify-js": "^2.4.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          }
-        }
-      }
-    },
-    "grunt-contrib-watch": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
-      "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.9",
-        "gaze": "~0.5.1",
-        "lodash": "~2.4.1",
-        "tiny-lr-fork": "0.0.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "grunt-lib-contrib": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/grunt-lib-contrib/-/grunt-lib-contrib-0.7.1.tgz",
-      "integrity": "sha1-tZ+ptqqkDagntJlfByDS3r92LpQ=",
-      "dev": true,
-      "requires": {
-        "maxmin": "~0.1.0",
-        "strip-path": "~0.1.0"
-      }
-    },
-    "grunt-sails-linker": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/grunt-sails-linker/-/grunt-sails-linker-0.9.6.tgz",
-      "integrity": "sha1-obVEI/l7aAVwhiM034Clww8PBAY=",
-      "dev": true
-    },
-    "grunt-sync": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/grunt-sync/-/grunt-sync-0.0.8.tgz",
-      "integrity": "sha1-zIM1wxc49QToIK+MeLhNm5cKb4Y=",
-      "dev": true,
-      "requires": {
-        "promised-io": "0.3.3"
-      }
-    },
-    "gzip-size": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-0.1.1.tgz",
-      "integrity": "sha1-rjNIO2/IIk6DQilt4Qjvk3V/duA=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.4.1",
-        "zlib-browserify": "^0.0.3"
-      }
-    },
-    "handlebars": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-      "dev": true,
-      "requires": {
-        "optimist": "^0.6.1",
-        "source-map": "^0.1.40",
-        "uglify-js": "~2.3"
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4892,27 +3599,6 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "has-binary": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
-      "dev": true
-    },
-    "has-cors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-      "dev": true
     },
     "has-flag": {
       "version": "1.0.0",
@@ -4941,26 +3627,6 @@
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
-    "hawk": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-      "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "boom": "0.4.x",
-        "cryptiles": "0.2.x",
-        "hoek": "0.9.x",
-        "sntp": "0.2.x"
-      }
-    },
-    "hoek": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-      "dev": true,
-      "optional": true
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -4970,12 +3636,6 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
       }
-    },
-    "hooker": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
-      "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
-      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -4990,25 +3650,14 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-      "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+      "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.1",
-        "statuses": "1"
-      }
-    },
-    "http-signature": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "asn1": "0.1.11",
-        "assert-plus": "^0.1.5",
-        "ctype": "0.5.3"
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "https-proxy-agent": {
@@ -5023,26 +3672,48 @@
       }
     },
     "i": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
-      "integrity": "sha1-HSuFQVjsgWkRPGy39raAHpniEdU=",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
+      "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0=",
       "dev": true
     },
-    "i18n": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.5.0.tgz",
-      "integrity": "sha1-Dad60n+CeF2KLbXGfGoso5l8G74=",
+    "i18n-2": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/i18n-2/-/i18n-2-0.7.3.tgz",
+      "integrity": "sha512-NiC0dd+VAVGq/hWsK19XCTwfx7Xr0KPtldQ11/9DHY8Ic4++bbgRhjCvRD1C/K09V7UZpwgVhQuzPPom9XVrOQ==",
       "dev": true,
       "requires": {
-        "debug": "*",
-        "mustache": "*",
-        "sprintf": ">=0.1.1"
+        "debug": "^3.1.0",
+        "sprintf-js": "^1.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.11.tgz",
-      "integrity": "sha1-LstC/SlHRJIiCaLnxATayHk9it4=",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "import-lazy": {
@@ -5058,19 +3729,23 @@
       "dev": true
     },
     "include-all": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/include-all/-/include-all-0.1.6.tgz",
-      "integrity": "sha1-qJZ2sIWGkYVIbr/poZy2mrhKZSs=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/include-all/-/include-all-4.0.3.tgz",
+      "integrity": "sha1-ZfBujxGJSxp7XsH8l+azOS98+nU=",
       "dev": true,
       "requires": {
-        "underscore.string": "2.3.1"
+        "@sailshq/lodash": "^3.10.2",
+        "merge-dictionaries": "^0.0.3"
       },
       "dependencies": {
-        "underscore.string": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.1.tgz",
-          "integrity": "sha1-4jKLDAmBio9hcCZCfTSPlq0Qmdk=",
-          "dev": true
+        "merge-dictionaries": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/merge-dictionaries/-/merge-dictionaries-0.0.3.tgz",
+          "integrity": "sha1-xN5NWNuyXkwoI6owy44VOQaet1c=",
+          "dev": true,
+          "requires": {
+            "@sailshq/lodash": "^3.10.2"
+          }
         }
       }
     },
@@ -5082,12 +3757,6 @@
       "requires": {
         "repeating": "^2.0.0"
       }
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -5106,9 +3775,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
-      "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "into-stream": {
@@ -5137,21 +3806,15 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
-      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-ci": {
@@ -5269,6 +3932,12 @@
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -5304,13 +3973,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
-      "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "~ 0.1.11",
-        "esprima": "~ 1.0.2"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -5343,6 +4012,17 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.1.tgz",
+      "integrity": "sha512-5DGfOTuTAMFzjNw56kwEQ9YqjCvRPHRbEmPkPSNPuK4DR4TmLQrZ1k0UdO8EJ9DKjOPqtyBjtlSnvzAC6kwUsg==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1",
+        "ono": "^5.0.1"
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5368,25 +4048,12 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
-      "integrity": "sha1-2k/WrXfxolUgPqY8e8Mtwx72RDM=",
-      "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
-    },
-    "jsonlint-lines": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz",
-      "integrity": "sha1-UH3mgNP7jEvhZBzFfW9nnynxeP8=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonparse": {
@@ -5424,15 +4091,6 @@
         "json-buffer": "3.0.0"
       }
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
@@ -5440,15 +4098,6 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "latest-version": {
@@ -5460,12 +4109,6 @@
         "package-json": "^4.0.0"
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -5475,44 +4118,13 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "less": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/less/-/less-1.7.5.tgz",
-      "integrity": "sha1-TyIM9yiKJ+rKc5325ICKLUwNV1Y=",
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "clean-css": "2.2.x",
-        "graceful-fs": "~3.0.2",
-        "mime": "~1.2.11",
-        "mkdirp": "~0.5.0",
-        "request": "~2.40.0",
-        "source-map": "0.1.x"
-      },
-      "dependencies": {
-        "clean-css": {
-          "version": "2.2.23",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-2.2.23.tgz",
-          "integrity": "sha1-BZC1R4tRbEkD7cLYm9P9vdKGMow=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "2.2.x"
-          }
-        },
-        "commander": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
-          "integrity": "sha1-F1rUuTF/P/YV8gHB5XIk9Vo+kd8=",
-          "dev": true,
-          "optional": true
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-          "dev": true,
-          "optional": true
-        }
+        "immediate": "~3.0.5"
       }
     },
     "load-json-file": {
@@ -5534,6 +4146,15 @@
           "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
           "dev": true
         }
+      }
+    },
+    "localforage": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
+      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
+      "dev": true,
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -5639,6 +4260,12 @@
         "lodash._isiterateecall": "^3.0.0"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5649,6 +4276,18 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.issafeinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.issafeinteger/-/lodash.issafeinteger-4.0.4.tgz",
+      "integrity": "sha1-sXbVmQ7GSdBr7cvOLwKOeJBJT5A=",
       "dev": true
     },
     "lodash.keys": {
@@ -5705,12 +4344,6 @@
         "lodash._reinterpolate": "~3.0.0"
       }
     },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -5737,40 +4370,85 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
-    "machine": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/machine/-/machine-4.1.1.tgz",
-      "integrity": "sha1-7y7KudSqwtvDl4UCl4o25x/ln9c=",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "convert-to-ecmascript-compatible-varname": "^0.1.0",
-        "debug": "^2.1.1",
-        "lodash": "~2.4.1",
-        "object-hash": "~0.3.0",
-        "rttc": "^1.0.2",
-        "switchback": "^1.1.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
-    "machinepack-urls": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/machinepack-urls/-/machinepack-urls-3.1.1.tgz",
-      "integrity": "sha1-1fswMs9KATXicoU1Bvawxm3plqo=",
+    "machine": {
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/machine/-/machine-15.2.2.tgz",
+      "integrity": "sha512-gXA/U4bjMyQd2QPw8i+AxzXEDkQBImQVE2P7mmTmXPcfszT+NJc5Me0I1Tn6Fj8zsO5EsmsFxD8Xdia751ik/w==",
       "dev": true,
       "requires": {
-        "machine": "^4.0.0"
+        "@sailshq/lodash": "^3.10.2",
+        "anchor": "^1.2.0",
+        "flaverr": "^1.7.0",
+        "parley": "^3.8.0",
+        "rttc": "^10.0.0-3"
+      }
+    },
+    "machine-as-action": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/machine-as-action/-/machine-as-action-10.3.0.tgz",
+      "integrity": "sha512-4DN6/e5L7dTCeOmK6VErxcqS1mfvU1vl9FAvqZuR/j+xHQoJUhwLgkW3CJXyPesL9+rvGWR5eBsv4o4s/DtxXQ==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "flaverr": "^1.5.1",
+        "machine": "^15.2.2",
+        "rttc": "^10.0.0-4",
+        "streamifier": "0.1.1"
+      }
+    },
+    "machinepack-fs": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/machinepack-fs/-/machinepack-fs-12.0.1.tgz",
+      "integrity": "sha512-5Hao0wOgLwUljQtmWKZDYbXNX29Otav9v5S8hxA43H2UP6KT3xFSE4cwwkBB9jHppgYtMqwGa0Q9TFC07hjFkg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "0.30.0",
+        "machine": "^15.0.0-12",
+        "walker": "1.0.7"
+      }
+    },
+    "machinepack-process": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/machinepack-process/-/machinepack-process-4.0.1.tgz",
+      "integrity": "sha512-/5dqpWVhNjRC78v4cOKMH2I74u3hbM4pVha0SEh427eddWLSDt41txECZh+HLPPD3h/r35UU0cKszIFxqZYJlA==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "machine": "^15.0.0-23",
+        "opn": "5.3.0"
+      }
+    },
+    "machinepack-redis": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/machinepack-redis/-/machinepack-redis-2.0.5.tgz",
+      "integrity": "sha512-K+5j93jaeFKKhtGc0VDVaW/42luxbVnN/XueLfXdJhFam+dMm+06iNzVC0xexZwx+MRfnpWiMOT2TncC+Vi07g==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.0.1",
+        "flaverr": "^1.9.2",
+        "machine": "^15.2.2",
+        "redis": "2.8.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        }
       }
     },
     "make-dir": {
@@ -5790,6 +4468,15 @@
         }
       }
     },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -5801,17 +4488,6 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
       "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
-    },
-    "maxmin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/maxmin/-/maxmin-0.1.0.tgz",
-      "integrity": "sha1-ldgcUonjqdMPf8fcVZwCTlAwydA=",
-      "dev": true,
-      "requires": {
-        "chalk": "^0.4.0",
-        "gzip-size": "^0.1.0",
-        "pretty-bytes": "^0.1.0"
-      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -5855,46 +4531,27 @@
       }
     },
     "merge-defaults": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.1.4.tgz",
-      "integrity": "sha1-kkDUlaPxUC0608oEGwMfAFmb8Xg=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.2.tgz",
+      "integrity": "sha512-rKkxPFgGDZfmen0IN8BKRsGEbFU3PdO0RhR1GjOk+BLJF7+LAIhs5bUG3s26FkbB5bfIn9il25KkntRGdqHQ3A==",
       "dev": true,
       "requires": {
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
+        "@sailshq/lodash": "^3.10.2"
       }
     },
     "merge-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz",
-      "integrity": "sha1-IWnPdTjhsMyH+4jhUC2EdLv3mGQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
-    "method-override": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.9.tgz",
-      "integrity": "sha1-vRUfLONM8Bp2ykAKuVwBKxAtj3E=",
+    "merge-dictionaries": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-dictionaries/-/merge-dictionaries-1.0.0.tgz",
+      "integrity": "sha1-eJbuGrGhVQ0yh6AxG323gEtpGTE=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "methods": "~1.1.2",
-        "parseurl": "~1.3.1",
-        "vary": "~1.1.1"
-      },
-      "dependencies": {
-        "vary": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-          "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
-          "dev": true
-        }
+        "@sailshq/lodash": "^3.10.2"
       }
     },
     "methods": {
@@ -5910,18 +4567,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.29.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -5989,53 +4646,11 @@
         "supports-color": "3.1.2"
       }
     },
-    "mock-req": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mock-req/-/mock-req-0.1.0.tgz",
-      "integrity": "sha1-jXw98qnKVEqIgUJgl/MFeXYnMDE=",
-      "dev": true
-    },
-    "mock-res": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mock-res/-/mock-res-0.1.0.tgz",
-      "integrity": "sha1-zpcYBud+gr+mu8LrBnO2EQDiGCQ=",
-      "dev": true
-    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
-    },
-    "morgan": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
-      "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
-      "dev": true,
-      "requires": {
-        "basic-auth": "~1.0.3",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
     },
     "ms": {
       "version": "2.0.0",
@@ -6044,37 +4659,18 @@
       "dev": true
     },
     "multiparty": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
-      "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.1.3.tgz",
+      "integrity": "sha1-PEPH/LGJbhdGBDap3Qtu8WaOT5Q=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9",
-        "stream-counter": "~0.2.0"
+        "fd-slicer": "~1.0.1"
       }
     },
-    "mustache": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
-      "integrity": "sha1-QCj3d4sXcIpImTCm5SrDvKDaQdA=",
-      "dev": true
-    },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "native-or-bluebird": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz",
-      "integrity": "sha1-OSHhECMtHreQ89rGG7NwUxx9NW4=",
-      "dev": true
-    },
-    "natives": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz",
-      "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
     "ncp": {
@@ -6083,10 +4679,31 @@
       "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
       "dev": true
     },
+    "nedb": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
+      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "binary-search-tree": "0.2.5",
+        "localforage": "^1.3.0",
+        "mkdirp": "~0.5.1",
+        "underscore": "~1.4.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        }
+      }
+    },
     "negotiator": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
-      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g=",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
     },
     "neo-async": {
@@ -6112,59 +4729,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "dev": true,
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "dev": true
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
-    "noptify": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
-      "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
-      "dev": true,
-      "requires": {
-        "nopt": "~2.0.0"
-      },
-      "dependencies": {
-        "nopt": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
-          "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        }
-      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -6456,45 +5020,11 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
-      "dev": true,
-      "optional": true
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
-    },
-    "object-component": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
-      "dev": true
-    },
-    "object-hash": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-0.3.0.tgz",
-      "integrity": "sha1-VIII5Ds2pE5NowutbFasU7iF50Q=",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-1.1.1.tgz",
-      "integrity": "sha1-8ilnQnP5T8sjDQLBlYqLlOye+Vw=",
-      "dev": true,
-      "requires": {
-        "object-keys": "~1.0.1"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6506,9 +5036,9 @@
       }
     },
     "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
     "once": {
@@ -6520,6 +5050,33 @@
         "wrappy": "1"
       }
     },
+    "ono": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.2.tgz",
+      "integrity": "sha512-6XDlkEDQCgHNOdWS5SQlCSEJrJ9Ifh6lGrI8llR/UYOOA83EUVCt+4eWo8LT0rvEfyYSYJG90ExJHnTJqsoPBA==",
+      "dev": true
+    },
+    "openapi-schemas": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.1.tgz",
+      "integrity": "sha512-dHzGmd4dQ9DQRUckgAVvD5OjoKWNfhCo5xVkK+3As+zkjL2ybrF+V7nshLLKXT84xCMnyT7ZVvQlqxlqBq/2jA==",
+      "dev": true
+    },
+    "openapi-types": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
+      "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg==",
+      "dev": true
+    },
+    "opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -6529,12 +5086,6 @@
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
       }
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
-      "dev": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -6730,6 +5281,23 @@
         }
       }
     },
+    "parasails": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/parasails/-/parasails-0.7.11.tgz",
+      "integrity": "sha512-KCy+uA3iZeSOXFnOsaeke98/xRkd4dm2C6PkMb6bKIbp4rpc26ytIvTwTRLOvUeVxkBzMhAStooS9baTWoJ8Zw==",
+      "dev": true
+    },
+    "parley": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/parley/-/parley-3.8.3.tgz",
+      "integrity": "sha512-9fSqT4J0jRNh+F/5EAqZvUSq232xjFXZJ3rXgKUXbIUUZ0ZPj6VjW83mI5UpVP8PMGHF3I8xycmvNjs9nQ3O8g==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "bluebird": "3.2.1",
+        "flaverr": "^1.5.1"
+      }
+    },
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -6745,37 +5313,10 @@
         "error-ex": "^1.2.0"
       }
     },
-    "parsejson": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-      "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
-      "dev": true,
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
-    "parseqs": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-      "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
-      "dev": true,
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
-    "parseuri": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
-      "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
-      "dev": true,
-      "requires": {
-        "better-assert": "~1.0.0"
-      }
-    },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "path-exists": {
@@ -6821,6 +5362,15 @@
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz",
+      "integrity": "sha1-ciHd1CSDU4vd+f6tlCp5/zFk9Xo=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -6846,12 +5396,6 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "pause": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
-      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10=",
-      "dev": true
-    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -6860,6 +5404,12 @@
       "requires": {
         "through": "~2.3"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -6889,27 +5439,21 @@
       }
     },
     "pkginfo": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
-      "integrity": "sha1-NJ27f/04CB/K3AhT32h/DHdEzWU=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
       "dev": true
     },
     "pluralize": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-0.0.12.tgz",
-      "integrity": "sha1-6TGC0CHVjn1lXeOFOkOuAqiYXYY=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-      "dev": true
-    },
-    "pretty-bytes": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-0.1.2.tgz",
-      "integrity": "sha1-zZApTVihyk6KXQ+5yCJZmIgazwA=",
       "dev": true
     },
     "private": {
@@ -6922,21 +5466,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
-    },
-    "promise": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
-      "integrity": "sha1-LOcp9rlLRcJoka0GAsXJDgTG7vY=",
-      "dev": true,
-      "requires": {
-        "asap": "~1.0.0"
-      }
-    },
-    "promised-io": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/promised-io/-/promised-io-0.3.3.tgz",
-      "integrity": "sha1-DqVWIYD/mJaW82r1tGIITKQWYEg=",
       "dev": true
     },
     "prompt": {
@@ -6959,13 +5488,13 @@
       "dev": true
     },
     "proxy-addr": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
-      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "dev": true,
       "requires": {
-        "forwarded": "~0.1.0",
-        "ipaddr.js": "1.0.5"
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
       }
     },
     "pseudomap": {
@@ -6993,9 +5522,9 @@
       "dev": true
     },
     "qs": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-      "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o=",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "query-string": {
@@ -7022,52 +5551,65 @@
       "dev": true
     },
     "range-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
-      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-      "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.13",
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "bytes": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
           "dev": true
         },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
           "dev": true
         }
       }
     },
     "rc": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
-      "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "~0.2.5",
+        "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
-        "minimist": "~0.0.7",
-        "strip-json-comments": "0.1.x"
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
       }
@@ -7123,6 +5665,29 @@
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
       }
+    },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "dev": true,
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
+      "integrity": "sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==",
+      "dev": true
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -7268,12 +5833,6 @@
         "jsesc": "~0.5.0"
       }
     },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
-    },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
@@ -7284,61 +5843,13 @@
       }
     },
     "reportback": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/reportback/-/reportback-0.1.9.tgz",
-      "integrity": "sha1-Yh9BMIvB1W0FXtAGNtwBdeEyz08=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/reportback/-/reportback-2.0.2.tgz",
+      "integrity": "sha512-EOF6vRKfXjI7ydRoOdXXeRTK1zgWq7mep8/32patt0FOnBap32eTSw6yCea/o0025PHmVB8crx5OxzZJ+/P34g==",
       "dev": true,
       "requires": {
-        "captains-log": "~0.11.5",
-        "lodash": "~2.4.1",
-        "merge-defaults": "~0.1.0",
-        "switchback": "~1.1.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "request": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
-      "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "aws-sign2": "~0.5.0",
-        "forever-agent": "~0.5.0",
-        "form-data": "~0.1.0",
-        "hawk": "1.1.1",
-        "http-signature": "~0.10.0",
-        "json-stringify-safe": "~5.0.0",
-        "mime-types": "~1.0.1",
-        "node-uuid": "~1.4.0",
-        "oauth-sign": "~0.3.0",
-        "qs": "~1.0.0",
-        "stringstream": "~0.0.4",
-        "tough-cookie": ">=0.12.0",
-        "tunnel-agent": "~0.4.0"
-      },
-      "dependencies": {
-        "mime-types": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
-          "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
-          "integrity": "sha1-UKk+K1r2aRwxvOpdrnjubqGQN2g=",
-          "dev": true,
-          "optional": true
-        }
+        "captains-log": "^2.0.2",
+        "switchback": "^2.0.1"
       }
     },
     "request-promise": {
@@ -7412,30 +5923,6 @@
       "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
-    "resolve": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz",
-      "integrity": "sha1-NMY0R8ZkxwWY0cmxJvxDsqJDEKQ=",
-      "dev": true
-    },
-    "response-time": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
-      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
-      "dev": true,
-      "requires": {
-        "depd": "~1.1.0",
-        "on-headers": "~1.0.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        }
-      }
-    },
     "responselike": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
@@ -7457,20 +5944,30 @@
       "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
       "dev": true
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "align-text": "^0.1.1"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
-    },
-    "rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-      "dev": true
     },
     "rndm": {
       "version": "1.2.0",
@@ -7478,21 +5975,57 @@
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
       "dev": true
     },
-    "rttc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rttc/-/rttc-1.0.2.tgz",
-      "integrity": "sha1-TTZCjpUoQrJ0P6cC5PVhoi9kje8=",
+    "router": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/router/-/router-1.3.2.tgz",
+      "integrity": "sha1-v6oWiIpSg9XuQNmZ2nqfoVKWpgw=",
       "dev": true,
       "requires": {
-        "lodash": "~2.4.1"
+        "array-flatten": "2.1.1",
+        "debug": "2.6.9",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "setprototypeof": "1.1.0",
+        "utils-merge": "1.0.1"
       },
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+        "array-flatten": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
+          "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
+      }
+    },
+    "rttc": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rttc/-/rttc-10.0.1.tgz",
+      "integrity": "sha512-wBsGNVaZ8K1qG0n5jxQ7dnOpvpewyQHGIjbMFYx8D16+51MM+FwkZwDPgH4GtnaTSzrNvrJriXFyvDi7OTZQ0A==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2"
       }
     },
     "run-auto": {
@@ -7523,522 +6056,229 @@
       "dev": true
     },
     "sails": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/sails/-/sails-0.11.5.tgz",
-      "integrity": "sha1-6UrtufhHxYRilvKZD+ApZcm+2p0=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sails/-/sails-1.2.3.tgz",
+      "integrity": "sha512-S40uoH/DzGDmm40OJL/TNLONTPxQcuzBEuceuflNXlGLl07POc8z15Bt8cnsfh7Cr6zbXBTQhIYl3ioZNJEisA==",
       "dev": true,
       "requires": {
-        "anchor": "~0.10.0",
-        "async": "~0.9.0",
-        "captains-log": "~0.11.8",
-        "colors": "~0.6.2",
-        "commander": "~2.1.0",
-        "connect": "2.30.0",
-        "connect-flash": "~0.1.1",
-        "cookie": "0.1.2",
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.5.0",
+        "captains-log": "^2.0.0",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "common-js-file-extensions": "1.0.2",
+        "compression": "1.7.1",
+        "connect": "3.6.5",
+        "cookie": "0.3.1",
+        "cookie-parser": "1.4.3",
         "cookie-signature": "1.0.6",
-        "ejs": "~0.8.4",
-        "ejs-locals": "~1.0.2",
-        "express": "^3.21.0",
-        "express-handlebars": "^2.0.0",
-        "fs-extra": "~0.8.1",
-        "glob": "~3.2.9",
-        "grunt": "0.4.2",
-        "grunt-cli": "~0.1.11",
-        "grunt-contrib-clean": "~0.5.0",
-        "grunt-contrib-coffee": "~0.10.1",
-        "grunt-contrib-concat": "~0.3.0",
-        "grunt-contrib-copy": "~0.5.0",
-        "grunt-contrib-cssmin": "~0.9.0",
-        "grunt-contrib-jst": "~0.6.0",
-        "grunt-contrib-less": "0.11.1",
-        "grunt-contrib-uglify": "~0.4.0",
-        "grunt-contrib-watch": "^0.6.0",
-        "grunt-sails-linker": "~0.9.5",
-        "grunt-sync": "~0.0.4",
-        "i18n": "~0.5.0",
-        "include-all": "~0.1.3",
-        "lodash": "~2.4.1",
-        "merge-defaults": "~0.1.0",
-        "method-override": "~2.3.0",
-        "mock-req": "0.1.0",
-        "mock-res": "0.1.0",
-        "node-uuid": "~1.4.0",
-        "pluralize": "~0.0.5",
-        "prompt": "~0.2.13",
-        "rc": "~0.5.0",
-        "reportback": "~0.1.4",
-        "sails-build-dictionary": "~0.10.1",
-        "sails-disk": "~0.10.0",
-        "sails-generate": "~0.12.0",
-        "sails-hook-sockets": "^0.12.2",
-        "sails-stringfile": "~0.3.0",
-        "sails-util": "~0.10.3",
-        "semver": "^4.3.2",
-        "skipper": "~0.5.5",
-        "uid-safe": "^1.0.1",
-        "waterline": "~0.10.17"
+        "csurf": "1.9.0",
+        "ejs": "2.5.7",
+        "express": "4.16.2",
+        "express-session": "1.15.6",
+        "flaverr": "^1.10.0",
+        "glob": "7.1.2",
+        "i18n-2": "0.7.3",
+        "include-all": "^4.0.0",
+        "machine": "^15.2.2",
+        "machine-as-action": "^10.3.0-0",
+        "machinepack-process": "^4.0.1",
+        "machinepack-redis": "^2.0.2",
+        "merge-defaults": "0.2.2",
+        "merge-dictionaries": "1.0.0",
+        "minimist": "0.0.10",
+        "parley": "^3.3.4",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "1.5.3",
+        "pluralize": "1.2.1",
+        "prompt": "0.2.14",
+        "rc": "1.2.8",
+        "router": "1.3.2",
+        "rttc": "^10.0.0-0",
+        "sails-generate": "^1.16.0-0",
+        "sails-stringfile": "^0.3.3",
+        "semver": "4.3.6",
+        "serve-favicon": "2.4.5",
+        "serve-static": "1.13.1",
+        "skipper": "^0.9.0-0",
+        "sort-route-addresses": "^0.0.3",
+        "uid-safe": "2.1.5",
+        "vary": "1.1.2",
+        "whelk": "^6.0.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
         },
         "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "0.3"
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
-      }
-    },
-    "sails-build-dictionary": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/sails-build-dictionary/-/sails-build-dictionary-0.10.1.tgz",
-      "integrity": "sha1-uMwhuX1CD2PRQXpEwmcclAJOPT0=",
-      "dev": true,
-      "requires": {
-        "include-all": "~0.1.2",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
       }
     },
     "sails-disk": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/sails-disk/-/sails-disk-0.10.10.tgz",
-      "integrity": "sha1-asXeoAlQz2VopT/hP9C4060yYP8=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sails-disk/-/sails-disk-1.1.2.tgz",
+      "integrity": "sha512-zdOUzgKUQizvwtanZ4UMFU19NJA4QgGc9idRrCE6AYbo4UQ4E1PoY2GarRZ/SSonG7FSpfnHKt4O7C5pC+VKxQ==",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
-        "fs-extra": "0.30.0",
-        "lodash": "3.10.1",
-        "waterline-criteria": "~1.0.1",
-        "waterline-cursor": "~0.0.6",
-        "waterline-errors": "~0.10.1"
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.0.1",
+        "machinepack-fs": "^12.0.1",
+        "nedb": "1.8.0"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "lodash": "^4.8.0"
           }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
         }
       }
     },
     "sails-generate": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/sails-generate/-/sails-generate-0.12.4.tgz",
-      "integrity": "sha1-hPkhq9eZUpKEjz3W6wGuxgSsM4s=",
+      "version": "1.16.13",
+      "resolved": "https://registry.npmjs.org/sails-generate/-/sails-generate-1.16.13.tgz",
+      "integrity": "sha512-RDeiNuARxwQPuAiYqIKsrZtd5S7GRq1HhErJY8artt/hqhatmph/+vTJgGHrTUxygr7hZR4JAUKiXxM/YNRRpw==",
       "dev": true,
       "requires": {
-        "async": "~0.2.9",
-        "fs-extra": "~0.8.1",
-        "lodash": "~2.4.1",
-        "merge-defaults": "~0.1.0",
-        "reportback": "~0.1.8",
-        "sails-generate-adapter": "~0.10.5",
-        "sails-generate-api": "~0.10.0",
-        "sails-generate-backend": "~0.12.2",
-        "sails-generate-controller": "~0.10.7",
-        "sails-generate-frontend": "~0.11.5",
-        "sails-generate-generator": "~0.10.0",
-        "sails-generate-gruntfile": "~0.10.10",
-        "sails-generate-model": "~0.10.10",
-        "sails-generate-new": "~0.10.19",
-        "sails-generate-sails.io.js": "~0.12.0",
-        "sails-generate-views": "~0.10.5",
-        "sails-generate-views-jade": "~0.10.3"
+        "@sailshq/lodash": "^3.10.3",
+        "async": "2.0.1",
+        "chalk": "1.1.3",
+        "cross-spawn": "4.0.2",
+        "flaverr": "^1.0.0",
+        "fs-extra": "0.30.0",
+        "machinepack-process": "^4.0.0",
+        "parasails": "^0.7.1",
+        "read": "1.0.7",
+        "reportback": "^2.0.1",
+        "sails.io.js-dist": "^1.0.0"
       },
       "dependencies": {
         "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-adapter": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/sails-generate-adapter/-/sails-generate-adapter-0.10.7.tgz",
-      "integrity": "sha1-/9U0BMwvY27NAyghwLmByFsFzVU=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-api": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/sails-generate-api/-/sails-generate-api-0.10.1.tgz",
-      "integrity": "sha1-FVCVe2DU8Dpjerb1nE9j2jom9As=",
-      "dev": true,
-      "requires": {
-        "async": "~0.2.9",
-        "lodash": "~2.4.1",
-        "merge-defaults": "~0.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-backend": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/sails-generate-backend/-/sails-generate-backend-0.12.6.tgz",
-      "integrity": "sha1-Ty5O9ztmOYivzUjBzVN2cR8yCdA=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-controller": {
-      "version": "0.10.9",
-      "resolved": "https://registry.npmjs.org/sails-generate-controller/-/sails-generate-controller-0.10.9.tgz",
-      "integrity": "sha1-GRtjX23KnjJx1eIVQZnlLVA0a+E=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0",
-        "pluralize": "0.0.9",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "pluralize": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-0.0.9.tgz",
-          "integrity": "sha1-zA2ivWdrRq8P2Wf6jTnaKdFRGUI=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-frontend": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/sails-generate-frontend/-/sails-generate-frontend-0.11.7.tgz",
-      "integrity": "sha1-nXeyAp1q2AFhc0fhi1YmojHJ8Co=",
-      "dev": true,
-      "requires": {
-        "lodash": ">=2.4.x",
-        "merge-defaults": ">=0.1.0",
-        "sails-generate-sails.io.js": "^0.12.0"
-      }
-    },
-    "sails-generate-generator": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/sails-generate-generator/-/sails-generate-generator-0.10.11.tgz",
-      "integrity": "sha1-+z2Pd10k63uZ809562YPXWY/Qcs=",
-      "dev": true,
-      "requires": {
-        "lodash": ">=2.4.x",
-        "merge-defaults": ">=0.1.0"
-      }
-    },
-    "sails-generate-gruntfile": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/sails-generate-gruntfile/-/sails-generate-gruntfile-0.10.11.tgz",
-      "integrity": "sha1-zUOadw8TraPLbj2kFpLqmF1oaVs=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-model": {
-      "version": "0.10.12",
-      "resolved": "https://registry.npmjs.org/sails-generate-model/-/sails-generate-model-0.10.12.tgz",
-      "integrity": "sha1-O8k6xzx2p7SJFUeSEPJ2c3xHH7k=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.0",
-        "merge-defaults": ">=0.1.0",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
-      }
-    },
-    "sails-generate-new": {
-      "version": "0.10.29",
-      "resolved": "https://registry.npmjs.org/sails-generate-new/-/sails-generate-new-0.10.29.tgz",
-      "integrity": "sha1-eL0B70gULDZ2nRrGvxbqcjqQOC8=",
-      "dev": true,
-      "requires": {
-        "async": "~1.2.0",
-        "cross-spawn-async": "^2.1.6",
-        "fs-extra": "*",
-        "lodash": "~3.9.0",
-        "merge-defaults": ">=0.2.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
-          "dev": true
-        },
-        "merge-defaults": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
-          "integrity": "sha1-3UIkjrlrtqUVIXJDIccv+Vg93oA=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "~2.4.1"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            }
+            "lodash": "^4.8.0"
           }
-        }
-      }
-    },
-    "sails-generate-sails.io.js": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/sails-generate-sails.io.js/-/sails-generate-sails.io.js-0.12.5.tgz",
-      "integrity": "sha1-7V2qWSyt7c731P8xT/T1uUXSp24=",
-      "dev": true,
-      "requires": {
-        "lodash": ">=2.4.x"
-      }
-    },
-    "sails-generate-views": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/sails-generate-views/-/sails-generate-views-0.10.8.tgz",
-      "integrity": "sha1-fVFes83mMx7e/8sq8+h2JtPgHZs=",
-      "dev": true,
-      "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
-    "sails-generate-views-jade": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/sails-generate-views-jade/-/sails-generate-views-jade-0.10.4.tgz",
-      "integrity": "sha1-7YF9wcIvRJQ/uUFoxXac3w9VhQk=",
+    "sails-hook-orm": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sails-hook-orm/-/sails-hook-orm-2.1.1.tgz",
+      "integrity": "sha512-O6BqlAOpsomXDo6aJyZtmWNn2NwKvONZEFEy5tMhuP682HRxZ40p4iWLz0mkLzAfonpcCr91YoXCXqlWzLkpEA==",
       "dev": true,
       "requires": {
-        "lodash": "~2.4.1",
-        "merge-defaults": ">=0.1.0"
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.0.1",
+        "chalk": "1.1.3",
+        "flaverr": "^1.8.0",
+        "parley": "^3.3.2",
+        "prompt": "0.2.14",
+        "sails-disk": "^1.0.0-0",
+        "waterline": "^0.13.5-0",
+        "waterline-utils": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "sails-hook-sockets": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/sails-hook-sockets/-/sails-hook-sockets-0.12.3.tgz",
-      "integrity": "sha1-6Q5BO4WAnAkwv73GcC80a/1kcuQ=",
-      "dev": true,
-      "requires": {
-        "lodash": "^2.4.1",
-        "machinepack-urls": "^3.1.1",
-        "semver": "^4.3.4",
-        "socket.io": "~1.4.3",
-        "socket.io-client": "~1.4.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "sails-stringfile": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sails-stringfile/-/sails-stringfile-0.3.2.tgz",
-      "integrity": "sha1-2k42Zqj5z9Ph80a/uBFqMD4cML0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/sails-stringfile/-/sails-stringfile-0.3.3.tgz",
+      "integrity": "sha512-m61lSEURCpKf2T7Df9lkG2eWBPGFKrhJZi8OF3TMQe7HGWyUpYdwKhV6rFsky1gY6g4ecvTZTAqwHXOE1AtaCA==",
       "dev": true,
       "requires": {
-        "colors": "*",
-        "lodash": "~2.4.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
+        "@sailshq/lodash": "^3.10.2",
+        "colors": "*"
       }
     },
-    "sails-util": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/sails-util/-/sails-util-0.10.6.tgz",
-      "integrity": "sha1-9pcZYu6Z1CmDeCFWiUDGmeyLE6k=",
-      "dev": true,
-      "requires": {
-        "fs-extra": "~0.8.1",
-        "json-stringify-safe": "~5.0.0",
-        "lodash": "~2.4.1",
-        "optimist": "~0.6.0",
-        "switchback": "~1.1.1",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
-      }
+    "sails.io.js-dist": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sails.io.js-dist/-/sails.io.js-dist-1.2.1.tgz",
+      "integrity": "sha512-fBMdntawlqd5N/1xL9Vu6l+J5zvy86jLUf0nFDal5McUeZzUy7PpNqq+Vx/F9KgItAyFJ7RoO3YltO9dD0Q5OQ==",
+      "dev": true
     },
     "semantic-release": {
       "version": "7.0.2",
@@ -8108,121 +6348,104 @@
       }
     },
     "send": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
-      "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "~2.2.0",
-        "depd": "~1.1.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
         "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
         "escape-html": "~1.0.3",
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "http-errors": "~1.3.1",
-        "mime": "1.3.4",
-        "ms": "0.7.1",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
         "on-finished": "~2.3.0",
-        "range-parser": "~1.0.3",
-        "statuses": "~1.2.1"
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
         },
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          },
+          "dependencies": {
+            "statuses": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+              "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+              "dev": true
+            }
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "statuses": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
-          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg=",
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
       }
     },
     "serve-favicon": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
-      "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",
+      "integrity": "sha512-s7F8h2NrslMkG50KxvlGdj+ApSwaLex0vexuJ9iFf3GLTIp1ph/l1qZvRe9T9TJEYZgmq72ZwJ2VYiAEtChknw==",
       "dev": true,
       "requires": {
-        "etag": "~1.7.0",
-        "fresh": "0.3.0",
-        "ms": "0.7.2",
-        "parseurl": "~1.3.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        }
-      }
-    },
-    "serve-index": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz",
-      "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
-      "dev": true,
-      "requires": {
-        "accepts": "~1.2.13",
-        "batch": "0.5.3",
-        "debug": "~2.2.0",
-        "escape-html": "~1.0.3",
-        "http-errors": "~1.3.1",
-        "mime-types": "~2.1.9",
-        "parseurl": "~1.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "ms": "2.0.0",
+        "parseurl": "~1.3.2",
+        "safe-buffer": "5.1.1"
       }
     },
     "serve-static": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
-      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
+        "encodeurl": "~1.0.1",
         "escape-html": "~1.0.3",
-        "parseurl": "~1.3.1",
-        "send": "0.13.2"
+        "parseurl": "~1.3.2",
+        "send": "0.16.1"
       }
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+      "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
       "dev": true
     },
     "shebang-command": {
@@ -8240,12 +6463,6 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -8253,119 +6470,61 @@
       "dev": true
     },
     "skipper": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/skipper/-/skipper-0.5.9.tgz",
-      "integrity": "sha1-WWABrEYZWS1GEm2zZNIYbYSug8w=",
+      "version": "0.9.0-4",
+      "resolved": "https://registry.npmjs.org/skipper/-/skipper-0.9.0-4.tgz",
+      "integrity": "sha512-7q4pC2mkaVC/YphYn7bFzlcsPTdr/h6qZqtX1rtO5gkPmmBO3+z/7D7BgpLSG3C6Ji/PXm4Wk2GwXyXWIXwZ2w==",
       "dev": true,
       "requires": {
-        "async": "~1.4.2",
-        "colors": "~1.1.2",
-        "connect": "^2.30.0",
-        "debug": "^2.1.1",
-        "dot-access": "1.0.0",
-        "lodash": "~2.4.1",
-        "multiparty": "~3.2.2",
-        "node-uuid": "~1.4.1",
-        "semver": "~5.0.1",
-        "skipper-disk": "~0.5.0",
-        "string_decoder": "~0.10.25-1"
+        "@sailshq/lodash": "^3.10.3",
+        "async": "2.0.1",
+        "body-parser": "1.18.2",
+        "debug": "3.1.0",
+        "multiparty": "4.1.3",
+        "semver": "4.3.6",
+        "skipper-disk": "~0.5.6",
+        "string_decoder": "0.10.31",
+        "uuid": "3.0.1"
       },
       "dependencies": {
         "async": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        },
-        "multiparty": {
-          "version": "3.2.10",
-          "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.2.10.tgz",
-          "integrity": "sha1-+JghtveRKb8R/5v5NPSRHew9KcM=",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.1.9",
-            "stream-counter": "~0.2.0"
+            "lodash": "^4.8.0"
           }
         },
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "skipper-disk": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/skipper-disk/-/skipper-disk-0.5.9.tgz",
-      "integrity": "sha1-sEUvKjQVgVFPPoWXIrUmi5Y4jNo=",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/skipper-disk/-/skipper-disk-0.5.12.tgz",
+      "integrity": "sha512-yyLOWT1WKY2h9NaUuG77XyhMti6vltRqp3ofN2ZTYoG3/V/SRLH1CjtZQ2Az6oqgMrfN8SZ83k3ptaOvB31YmQ==",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "fs-extra": "0.30.0",
-        "lodash": "3.10.1"
+        "@sailshq/lodash": "^3.10.2",
+        "debug": "3.1.0",
+        "fs-extra": "0.30.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "2.0.0"
           }
-        },
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -8381,173 +6540,6 @@
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
     },
-    "sntp": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "hoek": "0.9.x"
-      }
-    },
-    "socket.io": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
-      "integrity": "sha1-5XbzMM0L7WTlWz/SbfmRFBiEhns=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "engine.io": "1.6.11",
-        "has-binary": "0.1.7",
-        "socket.io-adapter": "0.4.0",
-        "socket.io-client": "1.4.8",
-        "socket.io-parser": "2.2.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-adapter": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
-      "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
-      "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "socket.io-parser": "2.2.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "json3": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
-          "integrity": "sha1-9u/JPAagTemuxTBT3yVZuxniA4s=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "socket.io-parser": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
-          "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
-          "dev": true,
-          "requires": {
-            "benchmark": "1.0.0",
-            "component-emitter": "1.1.2",
-            "debug": "0.7.4",
-            "isarray": "0.0.1",
-            "json3": "3.2.6"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
-    "socket.io-client": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
-      "integrity": "sha1-SBskHnPfFA6hpPsDSGqFrQl/VVg=",
-      "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.0",
-        "debug": "2.2.0",
-        "engine.io-client": "1.6.11",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.4",
-        "socket.io-parser": "2.2.6",
-        "to-array": "0.1.4"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-      "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
-      "dev": true,
-      "requires": {
-        "benchmark": "1.0.0",
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
-    },
     "sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -8557,13 +6549,13 @@
         "is-plain-obj": "^1.0.0"
       }
     },
-    "source-map": {
-      "version": "0.1.43",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+    "sort-route-addresses": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/sort-route-addresses/-/sort-route-addresses-0.0.3.tgz",
+      "integrity": "sha512-FK9GJty+MN4X5ml665lcgJe5y0zjF2wgnNVWS1yVnPFuCODCtMJx8B1rFN5NRwDaCbDGjc45OKkusqrx2GFL4g==",
       "dev": true,
       "requires": {
-        "amdefine": ">=0.0.4"
+        "@sailshq/lodash": "^3.10.2"
       }
     },
     "source-map-support": {
@@ -8633,10 +6625,10 @@
         "through2": "^2.0.2"
       }
     },
-    "sprintf": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
-      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+    "sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
     "sshpk": {
@@ -8707,14 +6699,11 @@
       "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg==",
       "dev": true
     },
-    "stream-counter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz",
-      "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~1.1.8"
-      }
+    "streamifier": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+      "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -8750,18 +6739,14 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true,
-      "optional": true
-    },
     "strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
@@ -8788,15 +6773,9 @@
       }
     },
     "strip-json-comments": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-      "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ=",
-      "dev": true
-    },
-    "strip-path": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-path/-/strip-path-0.1.1.tgz",
-      "integrity": "sha1-vLkonhBrkYF7hSBJG0OHyk+Gg9I=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
     "supports-color": {
@@ -8808,32 +6787,69 @@
         "has-flag": "^1.0.0"
       }
     },
-    "switchback": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/switchback/-/switchback-1.1.3.tgz",
-      "integrity": "sha1-EscBCTSNailvc5upEO64U/i25jE=",
+    "swagger-jsdoc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-3.4.0.tgz",
+      "integrity": "sha512-lS3dpULpwQ5TSfPF9d9nxyXicTjJMgBGu74g/GQ0r247QMVsgqa6cL9sJ0NtK2IGxzG3HozBcXKv7qo+ns+hqg==",
       "dev": true,
       "requires": {
-        "lodash": "~2.4.1"
+        "commander": "2.20.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.4",
+        "js-yaml": "3.13.1",
+        "swagger-parser": "8.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
+        },
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
-    "tape": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-0.2.2.tgz",
-      "integrity": "sha1-ZMz6S37PSgBgAH5hcW1CR4FnFjc=",
+    "swagger-methods": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.1.tgz",
+      "integrity": "sha512-+Wb4jXbZA724K1VriN1bFwUxoL0+Nr5vA4GT4Yz5rldxa+tG2aDjt5ONWeE6diviBbLTvncfuD3nQrPPFElYpA==",
+      "dev": true
+    },
+    "swagger-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.0.tgz",
+      "integrity": "sha512-zk6ig8J2B4OqCnBSIqO67/Ui96NTjuoX10YGa4YVlIlQzLpHUZbLFZaO+zSubQoqAiJxmpvlbUplEcFIsPCESA==",
       "dev": true,
       "requires": {
-        "deep-equal": "~0.0.0",
-        "defined": "~0.0.0",
-        "jsonify": "~0.0.0"
+        "call-me-maybe": "^1.0.1",
+        "json-schema-ref-parser": "^7.1.0",
+        "ono": "^5.0.1",
+        "openapi-schemas": "^1.0.0",
+        "openapi-types": "^1.3.5",
+        "swagger-methods": "^2.0.0",
+        "z-schema": "^4.1.0"
+      }
+    },
+    "switchback": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/switchback/-/switchback-2.0.5.tgz",
+      "integrity": "sha512-w9gnsTxR5geOKt45QUryhDP9KTLcOAqje9usR2VQ2ng8DfhaF+mkIcArxioMP/p6Z/ecKE58i2/B0DDlMJK1jw==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.3"
       }
     },
     "term-size": {
@@ -8898,12 +6914,6 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8964,36 +6974,10 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
-    "tiny-lr-fork": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
-      "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
-      "dev": true,
-      "requires": {
-        "debug": "~0.7.0",
-        "faye-websocket": "~0.4.3",
-        "noptify": "~0.0.3",
-        "qs": "~0.5.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-          "dev": true
-        },
-        "qs": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
-          "integrity": "sha1-MbGtBYVnZRxSaSFQa5qHk5EaA4Q=",
-          "dev": true
-        }
-      }
-    },
-    "to-array": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
     "to-fast-properties": {
@@ -9001,16 +6985,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
-    },
-    "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "punycode": "^1.4.1"
-      }
     },
     "travis-ci": {
       "version": "2.2.0",
@@ -9336,13 +7310,6 @@
       "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc=",
       "dev": true
     },
-    "tunnel-agent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "dev": true,
-      "optional": true
-    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -9356,13 +7323,13 @@
       "dev": true
     },
     "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
+        "mime-types": "~2.1.24"
       }
     },
     "typedarray": {
@@ -9371,44 +7338,6 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async": "~0.2.6",
-        "optimist": "~0.3.5",
-        "source-map": "~0.1.7"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "optimist": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wordwrap": "~0.0.2"
-          }
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "uid-number": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
@@ -9416,25 +7345,18 @@
       "dev": true
     },
     "uid-safe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
-      "integrity": "sha1-WNbF2r+N+9jVKDSDmAbAP9YUMjI=",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "dev": true,
       "requires": {
-        "base64-url": "1.2.1",
-        "native-or-bluebird": "~1.1.2"
+        "random-bytes": "~1.0.0"
       }
     },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-      "dev": true
-    },
     "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
       "dev": true
     },
     "underscore.string": {
@@ -9557,12 +7479,6 @@
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
-    "utf8": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
-      "integrity": "sha1-DP7FyAUtRKI+OqqQgQToB1+V39U=",
-      "dev": true
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9592,9 +7508,15 @@
       }
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+      "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -9608,15 +7530,15 @@
       }
     },
     "validator": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-4.4.0.tgz",
-      "integrity": "sha1-NeKVVd1feCb5cKTq7P+ebfbfPaY=",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-5.7.0.tgz",
+      "integrity": "sha1-eoelgUa2laxIYHEUHAxJ1n2gXlw=",
       "dev": true
     },
     "vary": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
-      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -9638,12 +7560,6 @@
         }
       }
     },
-    "vhost": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.2.tgz",
-      "integrity": "sha1-L7HezUxGaqiLD5NBrzPcGv8keNU=",
-      "dev": true
-    },
     "walk": {
       "version": "2.3.14",
       "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
@@ -9653,151 +7569,138 @@
         "foreachasync": "^3.0.0"
       }
     },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
     "waterline": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/waterline/-/waterline-0.10.31.tgz",
-      "integrity": "sha1-Bq7/jDy6W1+POn6kNBpcVA4i/xk=",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/waterline/-/waterline-0.13.6.tgz",
+      "integrity": "sha512-FnJqjGzhwX2vnk2GPa4SsME28zqDdf8PZzXjbkiBpb5flE4AOl/rgxB8OuG7wXBRKKQtG0hqvJIsJwdoWFdXJw==",
       "dev": true,
       "requires": {
-        "anchor": "~0.11.0",
-        "async": "~1.2.0",
-        "bluebird": "~2.9.25",
-        "deep-diff": "~0.3.0",
-        "lodash": "~3.9.1",
-        "prompt": "~0.2.14",
-        "switchback": "~2.0.0",
-        "waterline-criteria": "~0.11.1",
-        "waterline-schema": "~0.1.20"
-      },
-      "dependencies": {
-        "anchor": {
-          "version": "0.11.5",
-          "resolved": "https://registry.npmjs.org/anchor/-/anchor-0.11.5.tgz",
-          "integrity": "sha1-WjRQVJQu83JpLaWaMSwV9cHxD3g=",
-          "dev": true,
-          "requires": {
-            "@mapbox/geojsonhint": "1.2.1",
-            "@sailshq/lodash": "^3.10.2",
-            "validator": "4.4.0"
-          }
-        },
-        "async": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.9.3",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
-          "integrity": "sha1-AVnoaDL+/8bWHYUrEqlTuZSWvTI=",
-          "dev": true
-        },
-        "switchback": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/switchback/-/switchback-2.0.2.tgz",
-          "integrity": "sha1-ls8ODTY7VZ0Lt/8htip6qRDsYHk=",
-          "dev": true,
-          "requires": {
-            "lodash": "3.10.1"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-              "dev": true
-            }
-          }
-        },
-        "waterline-criteria": {
-          "version": "0.11.2",
-          "resolved": "https://registry.npmjs.org/waterline-criteria/-/waterline-criteria-0.11.2.tgz",
-          "integrity": "sha1-apEVVjd47531TEbF0Wh8unmoTqE=",
-          "dev": true,
-          "requires": {
-            "lodash": "~2.4.1"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
-    "waterline-criteria": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/waterline-criteria/-/waterline-criteria-1.0.1.tgz",
-      "integrity": "sha1-iHcFfsfWRyEAAXo6V/zJS2Kh/ak=",
-      "dev": true,
-      "requires": {
-        "lodash": "3.10.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        }
-      }
-    },
-    "waterline-cursor": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/waterline-cursor/-/waterline-cursor-0.0.7.tgz",
-      "integrity": "sha1-zNnP7WYdlK9gJ0lZQrX6J61l/rM=",
-      "dev": true,
-      "requires": {
-        "async": "1.5.2",
-        "lodash": "3.10.1"
+        "@sailshq/lodash": "^3.10.2",
+        "anchor": "^1.2.0",
+        "async": "2.0.1",
+        "encrypted-attr": "1.0.6",
+        "flaverr": "^1.8.3",
+        "lodash.issafeinteger": "4.0.4",
+        "parley": "^3.3.2",
+        "rttc": "^10.0.0-1",
+        "waterline-schema": "^1.0.0-20",
+        "waterline-utils": "^1.3.7"
       },
       "dependencies": {
         "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.8.0"
+          }
         }
       }
-    },
-    "waterline-errors": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/waterline-errors/-/waterline-errors-0.10.1.tgz",
-      "integrity": "sha1-7mNjKq3emTJxt1FLfKmNn9W4ai4=",
-      "dev": true
     },
     "waterline-schema": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/waterline-schema/-/waterline-schema-0.1.20.tgz",
-      "integrity": "sha1-/3AH2+ass2+ODq5ZrZ36HP+TdhM=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/waterline-schema/-/waterline-schema-1.0.0.tgz",
+      "integrity": "sha512-dSz/CvOLYMULKieB91+ZSv415+AVgrLhlSWbhpVHfpczIbKyj+zorsB5AG+ukGw1z0CPs6F1ib8MicBNjtwv6g==",
       "dev": true,
       "requires": {
-        "lodash": "~3.10.0"
+        "@sailshq/lodash": "^3.10.2",
+        "flaverr": "^1.8.1",
+        "rttc": "^10.0.0-1"
+      }
+    },
+    "waterline-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/waterline-utils/-/waterline-utils-1.4.2.tgz",
+      "integrity": "sha512-WsS1yRw8xT6O7iIK8oAcYr3/vhMYiTHdA/vQnU/JsGbcad2Xi4p8bie8/F+BoEyN7SEpBZ8nFT9OdszDAt7Ugg==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "async": "2.0.1",
+        "flaverr": "^1.1.1",
+        "fs-extra": "0.30.0",
+        "qs": "6.4.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+        "async": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+          "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.8.0"
+          }
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        }
+      }
+    },
+    "whelk": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/whelk/-/whelk-6.0.1.tgz",
+      "integrity": "sha512-C6jGmpclsvSYm3rNhCkrdIdGhL9Oh6A9jnSmTN4lfEbH+ENQvjP9qZ5UV9WWolfoumpIzTBVupk1qiVeLL7yYQ==",
+      "dev": true,
+      "requires": {
+        "@sailshq/lodash": "^3.10.2",
+        "chalk": "1.1.3",
+        "commander": "2.8.1",
+        "flaverr": "^1.7.0",
+        "machine": "^15.2.2",
+        "rttc": "^10.0.0-0",
+        "yargs": "3.4.5"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
       }
     },
     "which": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-      "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-      "dev": true
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "which-module": {
       "version": "2.0.0",
@@ -9943,26 +7846,10 @@
         }
       }
     },
-    "ws": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
-      "integrity": "sha1-wdb9FRXTzv8fCuJ1m/X9dwMKrR0=",
-      "dev": true,
-      "requires": {
-        "options": ">=0.0.5",
-        "ultron": "1.0.x"
-      }
-    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
-    },
-    "xmlhttprequest-ssl": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
-      "integrity": "sha1-O3dB/qSoZnWXbpCNKW1ERZYfqmc=",
       "dev": true
     },
     "xtend": {
@@ -9984,15 +7871,23 @@
       "dev": true
     },
     "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.4.5.tgz",
+      "integrity": "sha1-s5IXO3iSeS9nKWpgE8LXbRUxXrE=",
       "dev": true,
       "requires": {
         "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
         "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
+        "window-size": "0.1.0",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {
@@ -10012,19 +7907,31 @@
         }
       }
     },
-    "yeast": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-      "dev": true
-    },
-    "zlib-browserify": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/zlib-browserify/-/zlib-browserify-0.0.3.tgz",
-      "integrity": "sha1-JAzNv9AgP6hCsTDe77FBQSLIzFA=",
+    "z-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.1.1.tgz",
+      "integrity": "sha512-0aKvR9FgrghUXXndYNDmAEazl8jykuHSkqkmPw2ZSuTWuLcEscn1zUTbR3LEfyxHl5EEHpqqOpF+Sd7wZvuDxw==",
       "dev": true,
       "requires": {
-        "tape": "~0.2.2"
+        "commander": "^2.7.1",
+        "core-js": "^3.2.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^11.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==",
+          "dev": true
+        },
+        "validator": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+          "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "sails",
     "hook",
     "swagger",
+    "openapi",
     "json",
     "generator"
   ],
@@ -29,7 +30,10 @@
     "lodash": "^4.17.4",
     "mocha": "^3.5.0",
     "sails": "^1.1.0",
-    "travis-deploy-once": "^4.3.4",
-    "semantic-release": "7.0.2"
+    "sails-disk": "^1.1.2",
+    "sails-hook-orm": "^2.1.1",
+    "semantic-release": "7.0.2",
+    "swagger-jsdoc": "^3.4.0",
+    "travis-deploy-once": "^4.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "chai": "^4.1.1",
     "lodash": "^4.17.4",
     "mocha": "^3.5.0",
-    "sails": "~0.11.0",
+    "sails": "^1.1.0",
     "travis-deploy-once": "^4.3.4",
     "semantic-release": "7.0.2"
   }

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -4,66 +4,71 @@
 var Sails = require('sails').Sails;
 var swaggerDoc = require('../lib/swaggerDoc');
 var assert = require('chai').assert;
+var expect = require('chai').expect;
+var _ = require('lodash');
 
 describe('Basic tests ::', function () {
 
-    // Var to hold a running sails app instance
-    var sails;
+  // Var to hold a running sails app instance
+  var sails;
 
-    // Before running any tests, attempt to lift Sails
-    before(function (done) {
+  // Before running any tests, attempt to lift Sails
+  before(function (done) {
 
-        // Hook will timeout in 10 seconds
-        this.timeout(11000);
+    // Hook will timeout in 10 seconds
+    this.timeout(11000);
 
-        // Attempt to lift sails
-        Sails().lift({
-            hooks: {
-                // Load the hook
-                "swaggergenerator": require('../'),
-                // Skip grunt (unless your hook uses it)
-                "grunt": false
+    // Attempt to lift sails
+    Sails().lift({
+      blueprints: {
+        shortcuts: false,
+      },
+      hooks: {
+        // Load the hook
+        swaggergenerator: require('../'),
+        // Skip grunt (unless your hook uses it)
+        grunt: false
+      },
+      log: { level: "error" }
 
-            },
-            log: {level: "error"}
-
-        }, function (err, _sails) {
-            if (err) return done(err);
-            sails = _sails;
-            return done();
-
-        });
-
-    });
-
-    // After tests are complete, lower Sails
-    after(function (done) {
-
-        // Lower Sails (if it successfully lifted)
-        if (sails) {
-            return sails.lower(done);
-        }
-        // Otherwise just return
-        return done();
+    }, function (err, _sails) {
+      if (err) return done(err);
+      sails = _sails;
+      return done();
 
     });
 
-    // Test that Sails can lift with the hook in place
-    it('sails does not crash on loading our hook', function () {
-        return true;
-    });
+  });
 
-    describe('Swagger generator', function () {
-        it("should make sure tags don't have any other key apart from 'name'", function (done) {
-            var spec = swaggerDoc(sails, sails.hooks.swaggergenerator);
-            for (var i = 0; i < spec.tags.length; i++) {
-                assert.property(spec.tags[i], 'name', "Should contain name property");
-                assert.lengthOf(Object.keys(spec.tags[i]), 1, "Should be of length one ");
-            }
+  // After tests are complete, lower Sails
+  after(function (done) {
 
-            done();
-        });
+    // Lower Sails (if it successfully lifted)
+    if (sails) {
+      return sails.lower(done);
+    }
+    // Otherwise just return
+    return done();
+
+  });
+
+  // Test that Sails can lift with the hook in place
+  it('sails does not crash on loading our hook', function () {
+    return true;
+  });
+
+  describe('Swagger generator', function () {
+
+    it("should make sure tags only have valid properties", function (done) {
+      let hook = sails.hooks.swaggergenerator;
+      var spec = swaggerDoc(sails, hook._routes, hook);
+      for (var i = 0; i < spec.tags.length; i++) {
+        expect(_.omit(spec.tags[i], ['name', 'description', 'externalDocs']), 'invalid properties').to.be.empty;
+      }
+
+      done();
     });
+  });
 
 
 });


### PR DESCRIPTION
Refactor hook initialisation to run after Sails ready in order to
ensure that `sails.getActions()` returns appropriate content.

Replace removed `sails.controllers` with equivalent data structure
derived from `sails.getActions()` (work in progress).

Utilise model attribute `columnType` to infer more type info (work
in progress).

Addresses https://github.com/theo4u/sails-hook-swagger-generator/issues/11#issuecomment-437683002 and https://github.com/theo4u/sails-hook-swagger-generator/issues/39

closes #11 
closes #39 
closes #51 