### PR TITLE
Accept custom responses #35

### DIFF
--- a/lib/generators.js
+++ b/lib/generators.js
@@ -266,11 +266,11 @@ function _generatePaths(generated_routes, tags, customBlueprintMaps) {
                                      .concat(_getQueryParamsFromRouteQuery(route.query))
                                      .concat(_getBodyParamsFromRouteBody(route.body))
                                      .filter(_isNotExcludedParameters(excludeParameters)),
-                responses: {
+                responses: (route.responses ? route.responses : {
                     '200': {description: 'The requested resource'},
                     '404': {description: 'Resource not found'},
                     '500': {description: 'Internal server error'}
-                }
+                })
             };
 
             //for our route that alters db we need json form body


### PR DESCRIPTION
Accept custom responses. 

Example: 

```
'POST /pets': {
		action: 'addPets',
		controller: 'PetController',
		swagger: {
			summary: "Add a new pet",
			description: "Add a new pet.",
			responses: {
				"200": {
					"description": "successful operation",
					"schema": {
						"$ref": "#/definitions/Pet"
					}
				},
				"400": {
					"description": "Invalid ID supplied"
				},
				"404": {
					"description": "Pet not found"
				}
			},
		}
	},
```