### PR TITLE
fix: Update blueprint request body schema should not specified 'required'

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -585,6 +585,7 @@ Note that:
      - `addSelectQueryParam`
      - `addOmitQueryParam`
      - `addModelBodyParam`
+     - `addModelBodyParamUpdate`
      - `addResultOfArrayOfModels`
      - `addAssociationPathParam`
      - `addAssociationFKPathParam`

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -31,6 +31,7 @@ export enum Modifiers {
     ADD_SELECT_QUERY_PARAM = 'addSelectQueryParam',
     ADD_OMIT_QUERY_PARAM = 'addOmitQueryParam',
     ADD_MODEL_BODY_PARAM = 'addModelBodyParam',
+    ADD_MODEL_BODY_PARAM_UPDATE = 'addModelBodyParamUpdate',
     ADD_RESULT_OF_ARRAY_OF_MODELS = 'addResultOfArrayOfModels',
     ADD_ASSOCIATION_PATH_PARAM = 'addAssociationPathParam',
     ADD_ASSOCIATION_FK_PATH_PARAM = 'addAssociationFKPathParam',

--- a/lib/type-formatter.ts
+++ b/lib/type-formatter.ts
@@ -124,7 +124,7 @@ export const blueprintActionTemplates: BlueprintActionTemplates = {
     ],
     resultDescription: 'Responds with the newly updated **{globalId}** record as a JSON dictionary',
     notFoundDescription: 'Cannot update, **{globalId}** record with specified ID **NOT** found',
-    modifiers: [Modifiers.ADD_MODEL_BODY_PARAM, Modifiers.ADD_RESULT_OF_MODEL, Modifiers.ADD_RESULT_VALIDATION_ERROR, Modifiers.ADD_RESULT_NOT_FOUND, Modifiers.ADD_SHORTCUT_BLUEPRINT_ROUTE_NOTE]
+    modifiers: [Modifiers.ADD_MODEL_BODY_PARAM_UPDATE, Modifiers.ADD_RESULT_OF_MODEL, Modifiers.ADD_RESULT_VALIDATION_ERROR, Modifiers.ADD_RESULT_NOT_FOUND, Modifiers.ADD_SHORTCUT_BLUEPRINT_ROUTE_NOTE]
   },
   destroy: {
     summary: 'Delete {globalId} (destroy)',

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -48,6 +48,18 @@
         }
       },
       "pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/pet-without-required-constraint"
+          },
+          {
+            "required": [
+              "names"
+            ]
+          }
+        ]
+      },
+      "pet-without-required-constraint": {
         "description": "Sails ORM Model **Pet**",
         "properties": {
           "petID": {
@@ -83,6 +95,18 @@
         ]
       },
       "user": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/user-without-required-constraint"
+          },
+          {
+            "required": [
+              "names"
+            ]
+          }
+        ]
+      },
+      "user-without-required-constraint": {
         "description": "You might write a short summary of how this **User** model works and what it represents here.\n",
         "properties": {
           "id": {
@@ -982,55 +1006,7 @@
         "tags": [
           "Pet"
         ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "petID",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "uniqueItems": true,
-              "description": "Note Sails special attributes: autoIncrement",
-              "readOnly": true
-            },
-            "description": "Note Sails special attributes: autoIncrement"
-          },
-          {
-            "in": "query",
-            "name": "names",
-            "schema": {
-              "type": "string",
-              "example": "Pet's full name"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "owner",
-            "schema": {
-              "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/user"
-                }
-              ]
-            },
-            "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated"
-          },
-          {
-            "in": "query",
-            "name": "caredForBy",
-            "schema": {
-              "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/user"
-                }
-              ]
-            },
-            "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Responds with a JSON dictionary representing the newly created **Pet** instance",
@@ -1084,8 +1060,7 @@
             "schema": {
               "type": "string",
               "example": "Pet's full name"
-            },
-            "required": true
+            }
           },
           {
             "in": "query",
@@ -1474,8 +1449,7 @@
             "schema": {
               "type": "string",
               "example": "First Middle Last"
-            },
-            "required": true
+            }
           },
           {
             "in": "query",
@@ -2052,12 +2026,12 @@
           }
         },
         "requestBody": {
-          "description": "JSON dictionary representing the Pet instance to create.",
+          "description": "JSON dictionary representing the Pet instance to update.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/pet"
+                "$ref": "#/components/schemas/pet-without-required-constraint"
               }
             }
           }
@@ -2131,12 +2105,12 @@
           }
         },
         "requestBody": {
-          "description": "JSON dictionary representing the Pet instance to create.",
+          "description": "JSON dictionary representing the Pet instance to update.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/pet"
+                "$ref": "#/components/schemas/pet-without-required-constraint"
               }
             }
           }
@@ -2335,12 +2309,12 @@
           }
         },
         "requestBody": {
-          "description": "JSON dictionary representing the User instance to create.",
+          "description": "JSON dictionary representing the User instance to update.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/user"
+                "$ref": "#/components/schemas/user-without-required-constraint"
               }
             }
           }
@@ -2416,12 +2390,12 @@
           }
         },
         "requestBody": {
-          "description": "JSON dictionary representing the User instance to create.",
+          "description": "JSON dictionary representing the User instance to update.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/user"
+                "$ref": "#/components/schemas/user-without-required-constraint"
               }
             }
           }

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -89,10 +89,7 @@
               }
             ]
           }
-        },
-        "required": [
-          "names"
-        ]
+        }
       },
       "user": {
         "allOf": [
@@ -159,10 +156,7 @@
               "$ref": "#/components/schemas/pet"
             }
           }
-        },
-        "required": [
-          "names"
-        ]
+        }
       }
     },
     "parameters": {
@@ -1306,96 +1300,7 @@
           "User (ORM duplicate)",
           "User (ORM)"
         ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "id",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "uniqueItems": true,
-              "description": "Note Sails special attributes: autoIncrement"
-            },
-            "description": "Note Sails special attributes: autoIncrement"
-          },
-          {
-            "in": "query",
-            "name": "names",
-            "schema": {
-              "type": "string",
-              "example": "First Middle Last"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "email",
-            "schema": {
-              "type": "string",
-              "format": "email",
-              "description": "Just any old email"
-            },
-            "description": "Just any old email"
-          },
-          {
-            "in": "query",
-            "name": "sex",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "Male",
-                "Female"
-              ]
-            }
-          },
-          {
-            "in": "query",
-            "name": "ageLimit",
-            "schema": {
-              "type": "number",
-              "format": "double",
-              "maximum": 100,
-              "minimum": 15
-            }
-          },
-          {
-            "in": "query",
-            "name": "pets",
-            "schema": {
-              "description": "Array of **pet**'s or array of FK's when creating / updating / not populated",
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/pet"
-              }
-            },
-            "description": "Array of **pet**'s or array of FK's when creating / updating / not populated"
-          },
-          {
-            "in": "query",
-            "name": "favouritePet",
-            "schema": {
-              "description": "JSON dictionary representing the **pet** instance or FK when creating / updating / not populated",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/pet"
-                }
-              ]
-            },
-            "description": "JSON dictionary representing the **pet** instance or FK when creating / updating / not populated"
-          },
-          {
-            "in": "query",
-            "name": "neighboursPets",
-            "schema": {
-              "description": "Array of **pet**'s or array of FK's when creating / updating / not populated",
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/pet"
-              }
-            },
-            "description": "Array of **pet**'s or array of FK's when creating / updating / not populated"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Responds with a JSON dictionary representing the newly created **User** instance",

--- a/test/generators.test.ts
+++ b/test/generators.test.ts
@@ -11,8 +11,13 @@ describe('Generators', () => {
             const actual = generateSchemas({ user: { ...userModel, globalId: 'User', identity: 'user' } })
             const expected = {
                 user: {
+                  allOf: [
+                    { '$ref': '#/components/schemas/user-without-required-constraint' },
+                    { required: ['names'] },
+                  ]
+                },
+                'user-without-required-constraint': {
                     description: "Sails ORM Model **User**",
-                    required: ['names'],
                     properties: {
                         id: {
                             type: "number",


### PR DESCRIPTION
Sails Models include specification of `required` property for attributes. This should be enforced/specified for create blueprints but **NOT** update blueprints.

This change adds two variant schemas for each model:
- `{modelIdentity}` - variant containing `required`
- `{modelIdentity}-without-required-constraint` - used for updates