### PR TITLE
Ensure all `{modelIdentity}/{action}` actions are handled as 'model-related'

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -7,6 +7,9 @@
 
 /**
  * @swagger
+ * /allActions:
+ *   tags:
+ *     - User
  * tags:
  *   name: Auth Mgt
  *   description: User management and login
@@ -73,6 +76,15 @@ module.exports = {
   list2: list2,
 
   // override User blueprint
+  /**
+   * @swagger
+   *
+   * /create:
+   *   summary: Create User (**)
+   *   tags:
+   *     - User (ORM)
+   *     - User (ORM duplicate)
+   */
   create: (req, res) => {
     return res.json({ in: 'create' });
   },

--- a/api/controllers/user/findone.js
+++ b/api/controllers/user/findone.js
@@ -1,0 +1,37 @@
+module.exports = {
+
+  friendlyName: 'Get User (find one) (A2)',
+
+  description: '**Actions2** override of blueprint action: Look up the **User** record with the specified ID.',
+
+  inputs: {
+    _id: {
+      description: 'The ID of the user to look up (actions2 version)',
+      type: 'number',
+      isInteger: true,
+      required: true,
+      meta: { swagger: { readOnly: true } },
+    },
+  },
+
+  exits: {
+    success: {
+      description: 'Another success',
+      outputExample: 'Some dynamic message like this.',
+      meta: { swagger: { exclude: true } },
+    },
+    notFound: {
+      description: 'No user with the specified ID was found in the database (actions2 version)',
+      responseType: 'notFound',
+      statusCode: 404,
+    }
+  },
+
+  fn: async function ({ userId }) {
+    return {
+      message: 'TEST ACTIONS2 (foobar) ' + userId,
+    };
+
+  }
+
+};

--- a/api/models/Pet.js
+++ b/api/models/Pet.js
@@ -5,6 +5,14 @@
  * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
  */
 
+/**
+ * @swagger
+ *
+ * /create:
+ *   exclude: true
+ *
+ */
+
 module.exports = {
 
   primaryKey: 'petID',

--- a/config/routes.js
+++ b/config/routes.js
@@ -47,12 +47,6 @@ module.exports.routes = {
    *                                                                          *
    ***************************************************************************/
 
-  /** @swagger
-   * /clients/:client_id/user/:id:
-   *   delete:
-   *     summary: Client Op
-   *     description: This is not really useful - example only :)
-   */
   'delete /clients/:client_id/user/:id': 'UserController.destroy',
 
   'POST /user': {
@@ -62,7 +56,7 @@ module.exports.routes = {
   },
 
   'patch /user': {
-    model: 'user',
+    // model: 'user', // can be specified (consistent with default blueprints) but not necessary
     action: 'user/create',
   },
 

--- a/lib/generators.ts
+++ b/lib/generators.ts
@@ -754,7 +754,6 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
               },
             }
           });
-          console.log('YYY', pathEntry);
         },
 
         addResultOfModel: () => {

--- a/lib/generators.ts
+++ b/lib/generators.ts
@@ -376,7 +376,8 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
 
     if (route.middlewareType === MiddlewareType.BLUEPRINT && route.model) {
 
-      if(route.model.swagger?.modelSchema?.exclude === true) {
+      if (route.model.swagger?.modelSchema?.exclude === true
+        || route.model.swagger.actions?.[route.action]?.exclude === true) {
         return;
       }
 

--- a/lib/generators.ts
+++ b/lib/generators.ts
@@ -1,6 +1,6 @@
-import { SwaggerSailsModel, NameKeyMap, SwaggerRouteInfo, BlueprintActionTemplates, Defaults, MiddlewareType, Action2Response } from './interfaces';
+import { SwaggerSailsModel, NameKeyMap, SwaggerRouteInfo, BlueprintActionTemplates, Defaults, Action2Response } from './interfaces';
 import { Reference, Tag } from 'swagger-schema-official';
-import { swaggerTypes, sailsAttributePropertiesMap, validationsMap, actions2Responses } from './type-formatter';
+import { swaggerTypes, sailsAttributePropertiesMap, validationsMap, actions2Responses, blueprintParameterTemplates } from './type-formatter';
 import assign from 'lodash/assign';
 import defaults from 'lodash/defaults';
 import mapKeys from 'lodash/mapKeys';
@@ -11,7 +11,7 @@ import isFunction from 'lodash/isFunction';
 import forEach from 'lodash/forEach';
 import { OpenApi } from '../types/openapi';
 import set from 'lodash/set';
-import { map, omit, isEqual, reduce } from 'lodash';
+import { map, omit, isEqual, reduce, uniq } from 'lodash';
 import { attributeValidations, resolveRef, unrollSchema } from './utils';
 
 
@@ -366,59 +366,216 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
       return;
     }
 
-    let pathEntry: OpenApi.Operation;
+    /* overwrite: summary, description, externalDocs, operationId, tags, requestBody, servers, security
+     * merge: parameters (by in+name), responses (by statusCode) */
+    const pathEntry: OpenApi.Operation = {
+      summary: undefined,
+      description: undefined,
+      externalDocs: undefined,
+      operationId: undefined,
+      tags: undefined,
+      parameters: [],
+      responses: {},
+      ...cloneDeep(omit(route.swagger || {}, 'exclude')),
+    };
 
+    const resolveParameterRef = (p: OpenApi.Parameter | Reference): OpenApi.Parameter | Reference => {
+      const specWithDefaultParametersToBeMerged = {
+        components: { parameters: blueprintParameterTemplates }
+      } as OpenApi.OpenApi;
+      // resolve first with current spec, then try template params to be added later
+      return (resolveRef(specification, p) || resolveRef(specWithDefaultParametersToBeMerged, p)) as OpenApi.Parameter | Reference;
+    };
     const isParam = (inType: string, name: string): boolean => {
       return !!pathEntry.parameters
-        .map(parameter => resolveRef(specification, parameter) as OpenApi.Parameter)
+        .map(parameter => resolveParameterRef(parameter))
         .find(parameter => parameter && 'in' in parameter && parameter.in == inType && parameter.name == name);
-    }
+    };
+    const addParamIfDne = (p: OpenApi.Parameter | Reference) => {
+      const resolved = resolveParameterRef(p);
+      if (resolved && 'in' in resolved) {
+        if (!isParam(resolved.in, resolved.name)) {
+          pathEntry.parameters.push(p);
+        }
+      }
+    };
 
-    if (route.middlewareType === MiddlewareType.BLUEPRINT && route.model) {
+    if (route.actionType === 'actions2') {
+
+      // note: check before blueprint template as these may override template for specific action(s)
+
+      const patternVariables = route.variables || [];
+      if (route.actions2Machine?.inputs) {
+        forEach(route.actions2Machine.inputs, (value, key) => {
+          if(value.meta?.swagger?.exclude === true) {
+            return;
+          }
+          const _in = patternVariables.indexOf(key) >= 0 ? 'path' : 'query';
+          if(isParam(_in, key)) {
+            return;
+          }
+          const { description, ..._attribute } = value;
+          const attribute = {
+            ...omit(_attribute, attributeValidations),
+            validations: pick(_attribute, attributeValidations),
+
+          } as Sails.AttributeDefinition;
+          pathEntry.parameters.push({
+            in: _in,
+            name: key,
+            required: value.required || false,
+            schema: generateAttributeSchema(attribute),
+            description
+          })
+        })
+      }
+
+      if (route.actions2Machine?.exits) {
+        const exitResponses: NameKeyMap<OpenApi.Response> = {};
+
+        // actions2 may specify more than one 'exit' per 'statusCode' --> use oneOf (and attempt to merge)
+        forEach(route.actions2Machine.exits, (exit, exitName) => {
+
+          if(exit.meta?.swagger?.exclude === true) {
+            return;
+          }
+
+          let { statusCode, description } = actions2Responses[exitName as keyof Action2Response] || actions2Responses.success;
+          statusCode = exit.statusCode || statusCode;
+          description = exit.description || description;
+
+          // XXX TODO review support for responseType, viewTemplatePath, outputExample
+          // XXX TODO use deriveJsonSwaggerTypeFromExample() for 'content' otherwise don't use
+
+          if (exitResponses[statusCode]) {
+
+            // this statusCode already exists --> will contain 'oneOf' so add
+            const arr = (exitResponses[statusCode].content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
+            arr!.push({ type: 'object', description: description });
+
+          } else if(pathEntry.responses[statusCode]) {
+
+            // if not exists, check for response defined in source swagger and merge/massage to suit 'application/json' oneOf
+            const r = cloneDeep(pathEntry.responses[statusCode]);
+            if(!r.content) r.content = {};
+            if(!r.content['application/json']) r.content['application/json'] = {};
+            if(r.content['application/json'].schema) {
+              if (!(r.content['application/json'].schema as OpenApi.UpdatedSchema).oneOf) {
+                const s = r.content['application/json'].schema;
+                r.content['application/json'].schema = { oneOf: [s] };
+              }
+            } else {
+              r.content['application/json'].schema = { oneOf: [] };
+            }
+
+            // now add this exit to the merged/massaged response
+            const arr = (r.content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
+            arr!.push({ type: 'object', description: description });
+            exitResponses[statusCode] = r;
+
+          } else {
+
+            // dne, so add
+            exitResponses[statusCode] = {
+              description: description,
+              content: {
+                'application/json': {
+                  schema: { oneOf: [{ type: 'object', description: description }] }
+                }
+              }
+            };
+
+          }
+        });
+
+        // remove oneOf for single entries
+        forEach(exitResponses, resp => {
+          if ((resp.content?.['application/json'].schema as OpenApi.UpdatedSchema)?.oneOf) {
+            const arr = (resp.content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
+            if (arr!.length === 1) {
+              resp.content!['application/json'].schema = arr![0];
+            }
+          }
+        });
+
+        pathEntry.responses = {
+          ...pathEntry.responses,
+          ...exitResponses,
+        }
+        forEach(pathEntry.responses, (resp, statusCode) => { // ensure description
+          if (!resp.description) resp.description =  exitResponses[statusCode]?.description || '-';
+        });
+      }
+
+      // merge actions2 summary and description
+      defaults(
+        pathEntry,
+        {
+          summary: route.actions2Machine?.friendlyName || undefined,
+          description: route.actions2Machine?.description || undefined,
+        }
+      );
+
+    } // of if(actions2)
+
+    // handle blueprint actions and related documentation (from model and blueprint template)
+    if (route.model && route.blueprintAction) {
 
       if (route.model.swagger?.modelSchema?.exclude === true
-        || route.model.swagger.actions?.[route.action]?.exclude === true) {
+        || route.model.swagger.actions?.[route.blueprintAction]?.exclude === true) {
         return;
       }
 
-      const template = templates[route.action as keyof BlueprintActionTemplates] || {};
+      const template = templates[route.blueprintAction as keyof BlueprintActionTemplates] || {};
 
-      const subst = (str: string) => str ? str.replace('{globalId}', route.model!.globalId) : '';
+      const subst = (str: string) => str ? str.replace('{globalId}', route.model!.globalId) : undefined;
 
-      // handle special case of PK parameter
-      const parameters = [...(template.parameters || [])]
-        .map(parameter => {
-          if (parameter === 'primaryKeyPathParameter') {
-            const primaryKey = route.model!.primaryKey;
-            const attributeInfo = route.model!.attributes[primaryKey];
-            const pname = 'ModelPKParam-' + route.model!.identity;
-            if (components.parameters && !components.parameters[pname]) {
-              components.parameters[pname] = {
-                in: 'path',
-                name: '_' + primaryKey, // note '_' as per transformSailsPathsToSwaggerPaths()
-                required: true,
-                schema: generateAttributeSchema(attributeInfo),
-                description: subst('The desired **{globalId}** record\'s primary key value'),
-              };
-            }
-            return { $ref: '#/components/parameters/' + pname };
+      /* overwrite: summary, description, externalDocs, operationId, tags, requestBody, servers, security
+       * merge: parameters (by in+name), responses (by statusCode) */
+      defaults(
+        pathEntry,
+        {
+          summary: subst(template.summary),
+          description: subst(template.description),
+          externalDocs: template.externalDocs || undefined,
+          tags: route.model.swagger.modelSchema?.tags || route.model.swagger.actions?.allactions?.tags || [route.model.globalId],
+          ...cloneDeep(omit({
+            ...route.model.swagger.actions?.allactions || {},
+            ...route.model.swagger.actions?.[route.blueprintAction] || {},
+          }, 'exclude')),
+        }
+      );
+
+      // merge parameters from model actions and template (in that order)
+      (route.model.swagger.actions?.[route.blueprintAction]?.parameters || []).map(p => addParamIfDne(p));
+      (route.model.swagger.actions?.allactions?.parameters || []).map(p => addParamIfDne(p));
+
+      (template.parameters || []).map(parameter => {
+        // handle special case of PK parameter
+        if (parameter === 'primaryKeyPathParameter') {
+          const primaryKey = route.model!.primaryKey;
+          const attributeInfo = route.model!.attributes[primaryKey];
+          const pname = 'ModelPKParam-' + route.model!.identity;
+          if (components.parameters && !components.parameters[pname]) {
+            components.parameters[pname] = {
+              in: 'path',
+              name: '_' + primaryKey, // note '_' as per transformSailsPathsToSwaggerPaths()
+              required: true,
+              schema: generateAttributeSchema(attributeInfo),
+              description: subst('The desired **{globalId}** record\'s primary key value'),
+            };
           }
-          return parameter;
-        }) as Array<OpenApi.Parameter>;
+          parameter = { $ref: '#/components/parameters/' + pname };
+        }
+        addParamIfDne(parameter);
+      });
 
-      pathEntry = {
-        summary: subst(template.summary),
-        description: subst(template.description),
-        externalDocs: template.externalDocs || undefined,
-        tags: route.swagger?.tags || route.model.swagger.modelSchema?.tags || route.model.swagger.actions?.allactions?.tags || [route.model.globalId],
-        parameters,
-        responses: cloneDeep(defaultsValues.responses || {}),
-        ...cloneDeep(omit({
-          ...route.model.swagger.actions?.allactions || {},
-          ...route.model.swagger.actions?.[route.action] || {},
-        }, 'exclude')),
-        ...cloneDeep(omit(route.swagger || {}, 'exclude')),
-      };
+      // merge responses from model actions
+      defaults(
+        pathEntry.responses,
+        (route.model.swagger.actions?.[route.blueprintAction]?.responses || {}),
+        (route.model.swagger.actions?.allactions?.responses || {}),
+      );
 
       const modifiers = {
 
@@ -479,7 +636,7 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
         },
 
         addModelBodyParam: () => {
-          if(route.actionType === 'shortcutBlueprint') {
+          if(route.isShortcutBlueprintRoute) {
             const schema = specification!.components!.schemas?.[route.model!.identity];
             if (schema) {
               const resolvedSchema = unrollSchema(specification, schema);
@@ -493,7 +650,7 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
           } else {
             if (pathEntry.requestBody) return;
             pathEntry.requestBody = {
-              description: subst('JSON dictionary representing the {globalId} instance to create.'),
+              description: subst('JSON dictionary representing the {globalId} instance to create.'), // XXX TODO Incorporate model description?
               required: true,
               content: {
                 'application/json': {
@@ -505,7 +662,7 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
         },
 
         addModelBodyParamUpdate: () => {
-          if (route.actionType === 'shortcutBlueprint') {
+          if (route.isShortcutBlueprintRoute) {
             const schema = specification!.components!.schemas?.[route.model!.identity+'-without-required-constraint'];
             if (schema) {
               const resolvedSchema = resolveRef(specification, schema);
@@ -519,7 +676,7 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
           } else {
             if (pathEntry.requestBody) return;
             pathEntry.requestBody = {
-              description: subst('JSON dictionary representing the {globalId} instance to update.'),
+              description: subst('JSON dictionary representing the {globalId} instance to update.'), // XXX TODO Incorporate model description?
               required: true,
               content: {
                 'application/json': {
@@ -531,16 +688,18 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
         },
 
         addResultOfArrayOfModels: () => {
-          assign(pathEntry.responses['200'], {
-            description: subst(template.resultDescription),
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'array',
-                  items: { '$ref': '#/components/schemas/' + route.model!.identity },
+          defaults(pathEntry.responses, {
+            '200': {
+              description: subst(template.resultDescription || 'Array of **{globalId}** records'),
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: { '$ref': '#/components/schemas/' + route.model!.identity },
+                  },
                 },
               },
-            },
+            }
           });
         },
 
@@ -577,49 +736,54 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
             const assoc = associations.find(_assoc => _assoc.alias == a);
             return assoc ? (assoc.collection || assoc.model) : a;
           });
-          assign(pathEntry.responses['200'], {
-            description: subst(template.resultDescription),
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'array',
-                  // items: { type: 'any' },
-                  items: {
-                    oneOf: models.map(model => {
-                      return { '$ref': '#/components/schemas/' + model };
-                    }),
+          defaults(pathEntry.responses, {
+            '200': {
+              description: subst(template.resultDescription),
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    // items: { type: 'any' },
+                    items: {
+                      oneOf: uniq(models).map(model => {
+                        return { '$ref': '#/components/schemas/' + model };
+                      }),
+                    },
                   },
                 },
               },
-            },
+            }
           });
+          console.log('YYY', pathEntry);
         },
 
         addResultOfModel: () => {
-          assign(pathEntry.responses['200'], {
-            description: subst(template.resultDescription),
-            content: {
-              'application/json': {
-                schema: { '$ref': '#/components/schemas/' + route.model!.identity },
+          defaults(pathEntry.responses, {
+            '200': {
+              description: subst(template.resultDescription || '**{globalId}** record'),
+              content: {
+                'application/json': {
+                  schema: { '$ref': '#/components/schemas/' + route.model!.identity },
+                },
               },
-            },
+            }
           });
         },
 
         addResultNotFound: () => {
-          assign(pathEntry.responses['404'], {
-            description: subst(template.notFoundDescription || 'Not found'),
+          defaults(pathEntry.responses, {
+            '404': { description: subst(template.notFoundDescription || 'Not found'), }
           });
         },
 
         addResultValidationError: () => {
-          assign(pathEntry.responses['400'], {
-            description: subst('Validation errors; details in JSON response'),
+          defaults(pathEntry.responses, {
+            '400': { description: subst('Validation errors; details in JSON response'), }
           });
         },
 
         addFksBodyParam: () => {
-          if(route.actionType === 'shortcutBlueprint') {
+          if(route.isShortcutBlueprintRoute) {
             generateModelAssociationFKAttributeParameters(route.model!, route.associationAliases, models).map(p => {
               if(!route.associationAliases || route.associationAliases.indexOf(p.name) < 0) return;
               if (isParam('query', p.name)) return;
@@ -645,9 +809,9 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
         },
 
         addShortCutBlueprintRouteNote: () => {
-          if(route.actionType !== 'shortcutBlueprint') { return; }
+          if(!route.isShortcutBlueprintRoute) { return; }
           pathEntry.summary += ' *';
-          if(route.action === 'replace') {
+          if(route.blueprintAction === 'replace') {
             pathEntry.description += `\n\nOnly one of the query parameters, that matches the **association** path parameter, should be specified.`;
           }
           pathEntry.description += `\n\n(\\*) Note that this is a`
@@ -663,151 +827,25 @@ export const generatePaths = (routes: SwaggerRouteInfo[], templates: BlueprintAc
         else modifiers[modifier](); // standard modifier
       });
 
-      defaults(pathEntry.responses, {
-        '500': {
-          description: 'Internal server error',
-        }
-      });
+    } // of if (route.model && route.blueprintAction)
 
-    } else { // otherwise action
-
-      pathEntry = {
-        parameters: [],
-        responses: cloneDeep(defaultsValues.responses || {}),
-        ...cloneDeep(omit(route.swagger || {}, 'exclude')),
+    // final populate noting others above
+    defaults(
+      pathEntry,
+      {
+        summary: route.path || '',
+        tags: [route.actions2Machine?.friendlyName || route.defaultTagName],
       }
+    );
 
-      if (route.actionType === 'actions2') {
+    defaults(
+      pathEntry.responses,
+      defaultsValues.responses,
+      { '500': { description: 'Internal server error' } },
+    );
 
-        const patternVariables = route.variables || [];
-        if (route.actions2Machine?.inputs) {
-          forEach(route.actions2Machine.inputs, (value, key) => {
-            if(value.meta?.swagger?.exclude === true) {
-              return;
-            }
-            const _in = patternVariables.indexOf(key) >= 0 ? 'path' : 'query';
-            const isExisting = pathEntry.parameters.find(p => 'in' in p && p.in === _in && p.name === key)
-            if (isExisting) {
-              return
-            }
-            const { description, ..._attribute } = value;
-            const attribute = {
-              ...omit(_attribute, attributeValidations),
-              validations: pick(_attribute, attributeValidations),
-
-            } as Sails.AttributeDefinition;
-            pathEntry.parameters.push({
-              in: _in,
-              name: key,
-              required: value.required || false,
-              schema: generateAttributeSchema(attribute),
-              description
-            })
-          })
-        }
-
-        if (route.actions2Machine?.exits) {
-          const exitResponses: NameKeyMap<OpenApi.Response> = {};
-
-          // actions2 may specify more than one 'exit' per 'statusCode' --> use oneOf (and attempt to merge)
-          forEach(route.actions2Machine.exits, (exit, exitName) => {
-
-            if(exit.meta?.swagger?.exclude === true) {
-              return;
-            }
-
-            let { statusCode, description } = actions2Responses[exitName as keyof Action2Response] || actions2Responses.success;
-            statusCode = exit.statusCode || statusCode;
-            description = exit.description || description;
-
-            // XXX TODO review support for responseType, viewTemplatePath, outputExample
-            // XXX TODO use deriveJsonSwaggerTypeFromExample() for 'content' otherwise don't use
-
-            if (exitResponses[statusCode]) {
-
-              // this statusCode already exists --> will contain 'oneOf' so add
-              const arr = (exitResponses[statusCode].content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
-              arr!.push({ type: 'object', description: description });
-
-            } else if(pathEntry.responses[statusCode]) {
-
-              // if not exists, check for response defined in source swagger and merge/massage to suit 'application/json' oneOf
-              const r = cloneDeep(pathEntry.responses[statusCode]);
-              if(!r.content) r.content = {};
-              if(!r.content['application/json']) r.content['application/json'] = {};
-              if(r.content['application/json'].schema) {
-                if (!(r.content['application/json'].schema as OpenApi.UpdatedSchema).oneOf) {
-                  const s = r.content['application/json'].schema;
-                  r.content['application/json'].schema = { oneOf: [s] };
-                }
-              } else {
-                r.content['application/json'].schema = { oneOf: [] };
-              }
-
-              // now add this exit to the merged/massaged response
-              const arr = (r.content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
-              arr!.push({ type: 'object', description: description });
-              exitResponses[statusCode] = r;
-
-            } else {
-
-              // dne, so add
-              exitResponses[statusCode] = {
-                description: description,
-                content: {
-                  'application/json': {
-                    schema: { oneOf: [{ type: 'object', description: description }] }
-                  }
-                }
-              };
-
-            }
-          });
-
-          // remove oneOf for single entries
-          forEach(exitResponses, resp => {
-            if ((resp.content?.['application/json'].schema as OpenApi.UpdatedSchema)?.oneOf) {
-              const arr = (resp.content!['application/json'].schema as OpenApi.UpdatedSchema)!.oneOf;
-              if (arr!.length === 1) {
-                resp.content!['application/json'].schema = arr![0];
-              }
-            }
-          });
-
-          pathEntry.responses = {
-            ...pathEntry.responses,
-            ...exitResponses,
-          }
-          forEach(pathEntry.responses, (resp, statusCode) => { // ensure description
-            if (!resp.description) resp.description =  exitResponses[statusCode]?.description || '-';
-          });
-        }
-
-        // actions2 summary and description
-        defaults(
-          pathEntry,
-          {
-            summary: route.actions2Machine?.friendlyName || route.path || '',
-            description: route.actions2Machine?.description || undefined,
-            tags: route.swagger?.tags || [route.actions2Machine?.friendlyName || route.defaultTagName],
-          }
-        );
-
-      } // of if(actions2)
-
-      // final populate noting others above
-      defaults(
-        pathEntry,
-        {
-          summary: route.path || '',
-          tags: route.swagger?.tags || [route.defaultTagName],
-        }
-      );
-
-      // catch the case where defaultTagName not defined
-      if(isEqual(pathEntry.tags, [undefined])) pathEntry.tags = [];
-
-    }
+    // catch the case where defaultTagName not defined
+    if (isEqual(pathEntry.tags, [undefined])) pathEntry.tags = [];
 
     if (route.variables) {
       // now add patternVariables that don't already exist

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -18,7 +18,7 @@ export interface SwaggerGenerator {
  *
  * @see https://sailsjs.com/documentation/concepts/routes/custom-routes
  */
-export type ActionType = 'blueprint' | 'shortcutBlueprint' | 'controller' | 'standalone' | 'actions2' | 'function';
+export type ActionType = 'controller' | 'standalone' | 'actions2' | 'function';
 
 /**
  * Sails blueprint action types.
@@ -176,8 +176,8 @@ export type Action2Response = {
 export type HTTPMethodVerb = 'all' | 'get' | 'post' | 'put' | 'patch' | 'delete'
 
 export enum MiddlewareType {
-    BLUEPRINT = 'BLUEPRINT',
-    ACTION = 'ACTION'
+    BLUEPRINT = 'BLUEPRINT', //< Sails built-in blueprint middleware
+    ACTION = 'ACTION', //< custom action (may include specific per-model blueprint action overrides or custom blueprint actions)
 }
 
 /**
@@ -191,12 +191,14 @@ export interface SwaggerRouteInfo {
   variables: string[]; //< list of ALL variables extracted from path e.g. `/pet/:id` --> `id`
   optionalVariables: string[]; //< list of optional variables from path e.g. `/pet/:id?` // XXX TODO make Variable type
 
-  action: string; //< either blueprint action (e.g. 'find') or action identity (e.g. 'subdir/reporting/run')
-  actionType: ActionType; //< one of blueprint|shortcutBlueprint|controller|standalone|actions2|function
+  action: string; //< either blueprint action (e.g. 'user/find') or action identity (e.g. 'subdir/reporting/run')
+  actionType: ActionType; //< one of controller|standalone|actions2|function
   actions2Machine?: SwaggerSailsActions2Machine; //< for actionType === 'actions2', details of the action2 machine
 
-  model?: SwaggerSailsModel; //< reference to Sails Model (blueprints only)
+  model?: SwaggerSailsModel; //< reference to Sails Model (blueprints or custom model action only)
   associationAliases?: string[]; //< association attribute names (relevant blueprint routes only)
+  blueprintAction?: string; //< blueprint action (or custom model action) without model identity reference e.g. 'find' (only where model defined)
+  isShortcutBlueprintRoute?: boolean; //< true if the route matches a shortcut blueprint route
 
   defaultTagName?: string; //< default tag name for route, if any, based on Sails Model or Controller
 

--- a/lib/swagger-doc.ts
+++ b/lib/swagger-doc.ts
@@ -64,7 +64,7 @@ export default async (sails: Sails.Sails, sailsRoutes: Array<Sails.Route>, conte
    * @see https://github.com/balderdashy/sails/blob/master/lib/hooks/blueprints/index.js#L401
    */
   if(hookConfig.excludeDeprecatedPutBlueprintRoutes) {
-    routes = routes.filter(route => !(route.model && route.blueprintAction === 'update' && route.verb === 'put'));
+    routes = routes.filter(route => !(route.blueprintAction === 'update' && route.verb === 'put'));
   }
 
   mergeModelJsDoc(models, modelsJsDoc);

--- a/lib/swagger-doc.ts
+++ b/lib/swagger-doc.ts
@@ -64,7 +64,7 @@ export default async (sails: Sails.Sails, sailsRoutes: Array<Sails.Route>, conte
    * @see https://github.com/balderdashy/sails/blob/master/lib/hooks/blueprints/index.js#L401
    */
   if(hookConfig.excludeDeprecatedPutBlueprintRoutes) {
-    routes = routes.filter(route => !(route.actionType === 'blueprint' && route.action === 'update' && route.verb === 'put'));
+    routes = routes.filter(route => !(route.model && route.blueprintAction === 'update' && route.verb === 'put'));
   }
 
   mergeModelJsDoc(models, modelsJsDoc);

--- a/lib/transformations.ts
+++ b/lib/transformations.ts
@@ -84,7 +84,7 @@ export const transformSailsPathsToSwaggerPaths = (routes: SwaggerRouteInfo[]): v
   // step 1: filter to include path matched blueprint actions with a single association alias defined
   const routesToBeAggregated = boundRoutes.map(route => {
 
-    if (route.middlewareType === MiddlewareType.BLUEPRINT && actions.indexOf(route.action as BluePrintAction) >= 0
+    if (route.blueprintAction && actions.indexOf(route.blueprintAction as BluePrintAction) >= 0
       && route.associationAliases && route.associationAliases.length === 1) {
       const match = route.path.match(re);
       if (match && route.associationAliases[0]===match[2]) {
@@ -99,7 +99,7 @@ export const transformSailsPathsToSwaggerPaths = (routes: SwaggerRouteInfo[]): v
   const groupedByVerb = groupBy(routesToBeAggregated, r => r.route.verb);
   const thenByPathPrefix = mapValues(groupedByVerb, verbGroup => groupBy(verbGroup, r => r.match[1]));
   const thenByModelIdentity = mapValues(thenByPathPrefix, verbGroup => mapValues(verbGroup, prefixGroup => groupBy(prefixGroup, r => r.route.model!.identity)));
-  const thenByAction = mapValues(thenByModelIdentity, verbGroup => mapValues(verbGroup, prefixGroup => mapValues(prefixGroup, modelGroup => groupBy(modelGroup, r => r.route.action))));
+  const thenByAction = mapValues(thenByModelIdentity, verbGroup => mapValues(verbGroup, prefixGroup => mapValues(prefixGroup, modelGroup => groupBy(modelGroup, r => r.route.blueprintAction))));
 
   // const example = {
   //   get: { // <-- verb groups

--- a/lib/transformations.ts
+++ b/lib/transformations.ts
@@ -1,4 +1,4 @@
-import { NameKeyMap, SwaggerSailsModel, SwaggerModelAttribute, SwaggerSailsControllers, SwaggerControllerAttribute, SwaggerRouteInfo, BluePrintAction, SwaggerActionAttribute } from "./interfaces";
+import { NameKeyMap, SwaggerSailsModel, SwaggerModelAttribute, SwaggerSailsControllers, SwaggerControllerAttribute, SwaggerRouteInfo, BluePrintAction, SwaggerActionAttribute, MiddlewareType } from "./interfaces";
 import { forEach, defaults, cloneDeep, groupBy, mapValues, map } from "lodash";
 import { Tag } from "swagger-schema-official";
 import { OpenApi } from "../types/openapi";
@@ -324,7 +324,9 @@ export const mergeControllerSwaggerIntoRouteInfo = (sails: Sails.Sails, routes: 
       }
 
     } else {
-      sails.log.error(`ERROR: sails-hook-swagger-generator: Error resolving/loading controller action '${route.action}' source file`);
+      if(route.middlewareType === MiddlewareType.ACTION) {
+        sails.log.error(`ERROR: sails-hook-swagger-generator: Error resolving/loading controller action '${route.action}' source file`);
+      }
     }
 
   });

--- a/lib/transformations.ts
+++ b/lib/transformations.ts
@@ -1,4 +1,4 @@
-import { NameKeyMap, SwaggerSailsModel, SwaggerModelAttribute, SwaggerSailsControllers, SwaggerControllerAttribute, SwaggerRouteInfo, BluePrintAction, MiddlewareType, SwaggerActionAttribute } from "./interfaces";
+import { NameKeyMap, SwaggerSailsModel, SwaggerModelAttribute, SwaggerSailsControllers, SwaggerControllerAttribute, SwaggerRouteInfo, BluePrintAction, SwaggerActionAttribute } from "./interfaces";
 import { forEach, defaults, cloneDeep, groupBy, mapValues, map } from "lodash";
 import { Tag } from "swagger-schema-official";
 import { OpenApi } from "../types/openapi";
@@ -268,10 +268,6 @@ export const mergeControllerSwaggerIntoRouteInfo = (sails: Sails.Sails, routes: 
   controllers: SwaggerSailsControllers, controllersJsDoc: NameKeyMap<SwaggerControllerAttribute>): void => {
 
   routes.map(route => {
-
-    if(route.middlewareType !== MiddlewareType.ACTION) {
-      return;
-    }
 
     const mergeIntoDest = (source: SwaggerActionAttribute | undefined) => {
       if(!source) { return; }

--- a/lib/type-formatter.ts
+++ b/lib/type-formatter.ts
@@ -1,4 +1,6 @@
 import { BlueprintActionTemplates, Modifiers, Action2Response, Defaults } from './interfaces';
+import { OpenApi } from '../types/openapi';
+import { Reference } from 'swagger-schema-official';
 
 /* eslint-disable @typescript-eslint/camelcase */
 /**
@@ -205,7 +207,7 @@ export const blueprintActionTemplates: BlueprintActionTemplates = {
 /**
  * Defines standard parameters for generated Swagger for each Sails blueprint action routes.
  */
-export const blueprintParameterTemplates = {
+export const blueprintParameterTemplates: Record<string, OpenApi.Parameter | Reference> = {
   AttributeFilterParam: {
     in: 'query',
     name: '_*_',

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -989,86 +989,6 @@
         }
       }
     },
-    "/pet/create": {
-      "get": {
-        "summary": "Create Pet *",
-        "description": "Create a new **Pet** record.\n\n(\\*) Note that this is a [Sails blueprint shortcut route](https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes#?shortcut-blueprint-routes) (recommended for **development-mode only**)",
-        "externalDocs": {
-          "url": "https://sailsjs.com/documentation/reference/blueprint-api/create",
-          "description": "See https://sailsjs.com/documentation/reference/blueprint-api/create"
-        },
-        "tags": [
-          "Pet"
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "petID",
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "uniqueItems": true,
-              "description": "Note Sails special attributes: autoIncrement",
-              "readOnly": true
-            },
-            "description": "Note Sails special attributes: autoIncrement"
-          },
-          {
-            "in": "query",
-            "name": "names",
-            "schema": {
-              "type": "string",
-              "example": "Pet's full name"
-            },
-            "required": true
-          },
-          {
-            "in": "query",
-            "name": "owner",
-            "schema": {
-              "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/user"
-                }
-              ]
-            },
-            "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated"
-          },
-          {
-            "in": "query",
-            "name": "caredForBy",
-            "schema": {
-              "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated",
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/user"
-                }
-              ]
-            },
-            "description": "JSON dictionary representing the **user** instance or FK when creating / updating / not populated"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Responds with a JSON dictionary representing the newly created **Pet** instance",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/pet"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
     "/pet/update/{_petID}": {
       "get": {
         "summary": "Update Pet *",
@@ -1924,47 +1844,6 @@
           },
           "500": {
             "description": "Internal server error"
-          }
-        }
-      },
-      "post": {
-        "summary": "Create Pet",
-        "description": "Create a new **Pet** record.",
-        "externalDocs": {
-          "url": "https://sailsjs.com/documentation/reference/blueprint-api/create",
-          "description": "See https://sailsjs.com/documentation/reference/blueprint-api/create"
-        },
-        "tags": [
-          "Pet"
-        ],
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Responds with a JSON dictionary representing the newly created **Pet** instance",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/pet"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "requestBody": {
-          "description": "JSON dictionary representing the Pet instance to create.",
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/pet"
-              }
-            }
           }
         }
       }

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -298,6 +298,9 @@
               }
             }
           },
+          "400": {
+            "description": "Validation errors; details in JSON response"
+          },
           "404": {
             "description": "Resource not found"
           },
@@ -339,6 +342,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation errors; details in JSON response"
           },
           "404": {
             "description": "Resource not found"
@@ -566,6 +572,9 @@
           "200": {
             "description": "Success"
           },
+          "404": {
+            "description": "Resource not found"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -627,6 +636,9 @@
         "responses": {
           "200": {
             "description": "logout result"
+          },
+          "404": {
+            "description": "Resource not found"
           },
           "500": {
             "description": "Internal server error"
@@ -709,6 +721,9 @@
           "200": {
             "description": "Success"
           },
+          "404": {
+            "description": "Resource not found"
+          },
           "500": {
             "description": "Internal server error"
           }
@@ -729,6 +744,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "404": {
+            "description": "Resource not found"
           },
           "500": {
             "description": "Internal server error"
@@ -803,6 +821,7 @@
           "url": "https://somewhere.com/yep",
           "description": "Refer to these docs for more info"
         },
+        "operationId": "user/logout",
         "tags": [
           "Auth Mgt"
         ],
@@ -839,11 +858,13 @@
           "200": {
             "description": "logout result"
           },
+          "404": {
+            "description": "Resource not found"
+          },
           "500": {
             "description": "Internal server error"
           }
-        },
-        "operationId": "user/logout"
+        }
       }
     },
     "/clients/{client_id}/user/{_id}": {
@@ -1111,6 +1132,9 @@
               }
             }
           },
+          "400": {
+            "description": "Validation errors; details in JSON response"
+          },
           "404": {
             "description": "Cannot update, **Pet** record with specified ID **NOT** found"
           },
@@ -1240,8 +1264,8 @@
     },
     "/user/find/{_id}": {
       "get": {
-        "summary": "Get User (find one) *",
-        "description": "_Alternate description_: Look up the **User** record with the specified ID.\n\n(\\*) Note that this is a [Sails blueprint shortcut route](https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes#?shortcut-blueprint-routes) (recommended for **development-mode only**)",
+        "summary": "Get User (find one) (A2) *",
+        "description": "**Actions2** override of blueprint action: Look up the **User** record with the specified ID.\n\n(\\*) Note that this is a [Sails blueprint shortcut route](https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes#?shortcut-blueprint-routes) (recommended for **development-mode only**)",
         "externalDocs": {
           "url": "https://somewhere.com/yep",
           "description": "Refer to these docs for more info"
@@ -1252,7 +1276,15 @@
         ],
         "parameters": [
           {
-            "$ref": "#/components/parameters/ModelPKParam-user"
+            "in": "path",
+            "name": "_id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "readOnly": true
+            },
+            "description": "The ID of the user to look up (actions2 version)"
           },
           {
             "in": "query",
@@ -1297,7 +1329,15 @@
             }
           },
           "404": {
-            "description": "Response denoting **User** record with specified ID **NOT** found"
+            "description": "No user with the specified ID was found in the database (actions2 version)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "No user with the specified ID was found in the database (actions2 version)"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error"
@@ -1417,6 +1457,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation errors; details in JSON response"
           },
           "404": {
             "description": "Resource not found"
@@ -1541,6 +1584,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation errors; details in JSON response"
           },
           "404": {
             "description": "Cannot update, **User** record with specified ID **NOT** found"
@@ -1987,6 +2033,9 @@
               }
             }
           },
+          "400": {
+            "description": "Validation errors; details in JSON response"
+          },
           "404": {
             "description": "Cannot update, **Pet** record with specified ID **NOT** found"
           },
@@ -2113,9 +2162,6 @@
                     "oneOf": [
                       {
                         "$ref": "#/components/schemas/user"
-                      },
-                      {
-                        "$ref": "#/components/schemas/user"
                       }
                     ]
                   }
@@ -2134,8 +2180,8 @@
     },
     "/user/{_id}": {
       "get": {
-        "summary": "Get User (find one)",
-        "description": "_Alternate description_: Look up the **User** record with the specified ID.",
+        "summary": "Get User (find one) (A2)",
+        "description": "**Actions2** override of blueprint action: Look up the **User** record with the specified ID.",
         "externalDocs": {
           "url": "https://somewhere.com/yep",
           "description": "Refer to these docs for more info"
@@ -2146,7 +2192,15 @@
         ],
         "parameters": [
           {
-            "$ref": "#/components/parameters/ModelPKParam-user"
+            "in": "path",
+            "name": "_id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "readOnly": true
+            },
+            "description": "The ID of the user to look up (actions2 version)"
           },
           {
             "in": "query",
@@ -2191,7 +2245,15 @@
             }
           },
           "404": {
-            "description": "Response denoting **User** record with specified ID **NOT** found"
+            "description": "No user with the specified ID was found in the database (actions2 version)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "No user with the specified ID was found in the database (actions2 version)"
+                }
+              }
+            }
           },
           "500": {
             "description": "Internal server error"
@@ -2224,6 +2286,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Validation errors; details in JSON response"
           },
           "404": {
             "description": "Cannot update, **User** record with specified ID **NOT** found"
@@ -2574,12 +2639,6 @@
                   "type": "array",
                   "items": {
                     "oneOf": [
-                      {
-                        "$ref": "#/components/schemas/pet"
-                      },
-                      {
-                        "$ref": "#/components/schemas/pet"
-                      },
                       {
                         "$ref": "#/components/schemas/pet"
                       }

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -276,7 +276,7 @@
     },
     "/user": {
       "post": {
-        "summary": "Create User",
+        "summary": "Create User (**)",
         "description": "Create a new **User** record.",
         "externalDocs": {
           "url": "https://somewhere.com/yep",
@@ -318,7 +318,7 @@
         }
       },
       "patch": {
-        "summary": "Create User",
+        "summary": "Create User (**)",
         "description": "Create a new **User** record.",
         "externalDocs": {
           "url": "https://somewhere.com/yep",
@@ -554,6 +554,10 @@
       "post": {
         "summary": "Authentication",
         "description": "This is for authentication of any user",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "User"
         ],
@@ -561,6 +565,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         },
         "requestBody": {
@@ -590,6 +597,10 @@
       "get": {
         "summary": "Perform Logout",
         "description": "Logout of the application",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "Auth Mgt"
         ],
@@ -616,6 +627,9 @@
         "responses": {
           "200": {
             "description": "logout result"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -624,6 +638,10 @@
       "get": {
         "summary": "/user/list",
         "description": "Return a user list",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "User List"
         ],
@@ -645,6 +663,10 @@
       "get": {
         "summary": "/user/list2",
         "description": "Return a user list (alternate)",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "User List"
         ],
@@ -665,6 +687,10 @@
     "/user/upload": {
       "get": {
         "summary": "/user/upload",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "User"
         ],
@@ -682,6 +708,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         }
       }
@@ -689,6 +718,10 @@
     "/user/roles": {
       "put": {
         "summary": "update user roles",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "User (Extra)"
         ],
@@ -696,6 +729,9 @@
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         },
         "requestBody": {
@@ -763,6 +799,10 @@
       "get": {
         "summary": "Phone No. Logout",
         "description": "Alternate description (of no real significance)",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
         "tags": [
           "Auth Mgt"
         ],
@@ -798,14 +838,29 @@
         "responses": {
           "200": {
             "description": "logout result"
+          },
+          "500": {
+            "description": "Internal server error"
           }
         },
         "operationId": "user/logout"
       }
     },
-    "/clients/{client_id}/user/{id}": {
+    "/clients/{client_id}/user/{_id}": {
       "delete": {
+        "summary": "Delete User (destroy)",
+        "description": "Delete the **User** record with the specified ID.",
+        "externalDocs": {
+          "url": "https://somewhere.com/yep",
+          "description": "Refer to these docs for more info"
+        },
+        "tags": [
+          "User"
+        ],
         "parameters": [
+          {
+            "$ref": "#/components/parameters/ModelPKParam-user"
+          },
           {
             "in": "path",
             "name": "client_id",
@@ -814,32 +869,26 @@
               "type": "string"
             },
             "description": "Route pattern variable `client_id`"
-          },
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Route pattern variable `id`"
           }
         ],
         "responses": {
           "200": {
-            "description": "The requested resource"
+            "description": "Responds with a JSON dictionary representing the destroyed **User** instance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Resource not found"
+            "description": "Cannot destroy, **User** record with specified ID **NOT** found"
           },
           "500": {
             "description": "Internal server error"
           }
-        },
-        "summary": "/clients/{client_id}/user/{id}",
-        "tags": [
-          "User"
-        ]
+        }
       }
     },
     "/pet/find": {
@@ -1258,7 +1307,7 @@
     },
     "/user/create": {
       "get": {
-        "summary": "Create User *",
+        "summary": "Create User (**) *",
         "description": "Create a new **User** record.\n\n(\\*) Note that this is a [Sails blueprint shortcut route](https://sailsjs.com/documentation/concepts/blueprints/blueprint-routes#?shortcut-blueprint-routes) (recommended for **development-mode only**)",
         "externalDocs": {
           "url": "https://somewhere.com/yep",
@@ -1511,8 +1560,7 @@
           "description": "Refer to these docs for more info"
         },
         "tags": [
-          "User (ORM duplicate)",
-          "User (ORM)"
+          "User"
         ],
         "parameters": [
           {
@@ -2204,8 +2252,7 @@
           "description": "Refer to these docs for more info"
         },
         "tags": [
-          "User (ORM duplicate)",
-          "User (ORM)"
+          "User"
         ],
         "parameters": [
           {

--- a/test/fixtures/generatedSwagger.json
+++ b/test/fixtures/generatedSwagger.json
@@ -160,6 +160,18 @@
       }
     },
     "parameters": {
+      "ModelPKParam-user": {
+        "in": "path",
+        "name": "_id",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int64",
+          "uniqueItems": true,
+          "description": "Note Sails special attributes: autoIncrement"
+        },
+        "description": "The desired **User** record's primary key value"
+      },
       "ModelPKParam-pet": {
         "in": "path",
         "name": "_petID",
@@ -172,18 +184,6 @@
           "readOnly": true
         },
         "description": "The desired **Pet** record's primary key value"
-      },
-      "ModelPKParam-user": {
-        "in": "path",
-        "name": "_id",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int64",
-          "uniqueItems": true,
-          "description": "Note Sails special attributes: autoIncrement"
-        },
-        "description": "The desired **User** record's primary key value"
       },
       "AttributeFilterParam": {
         "in": "query",
@@ -442,6 +442,11 @@
     },
     "/actions2": {
       "get": {
+        "summary": "Friendly",
+        "description": "Return a user list",
+        "tags": [
+          "Actions2 Group"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -500,16 +505,16 @@
           "500": {
             "description": "An unexpected error occurred"
           }
-        },
-        "tags": [
-          "Actions2 Group"
-        ],
-        "description": "Return a user list",
-        "summary": "Friendly"
+        }
       }
     },
     "/twofind": {
       "get": {
+        "summary": "Example only",
+        "description": "You would not usually apply the same summary/description to all actions/paths :)",
+        "tags": [
+          "NomodelTwo"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -521,16 +526,16 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "summary": "Example only",
-        "description": "You would not usually apply the same summary/description to all actions/paths :)",
-        "tags": [
-          "NomodelTwo"
-        ]
+        }
       }
     },
     "/twoclear": {
       "get": {
+        "summary": "Example only",
+        "description": "You would not usually apply the same summary/description to all actions/paths :)",
+        "tags": [
+          "NomodelTwo"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -542,24 +547,22 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "summary": "Example only",
-        "description": "You would not usually apply the same summary/description to all actions/paths :)",
-        "tags": [
-          "NomodelTwo"
-        ]
+        }
       }
     },
     "/user/login": {
       "post": {
+        "summary": "Authentication",
+        "description": "This is for authentication of any user",
+        "tags": [
+          "User"
+        ],
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
           }
         },
-        "summary": "Authentication",
-        "description": "This is for authentication of any user",
         "requestBody": {
           "content": {
             "application/json": {
@@ -580,14 +583,16 @@
               }
             }
           }
-        },
-        "tags": [
-          "User"
-        ]
+        }
       }
     },
     "/user/logout": {
       "get": {
+        "summary": "Perform Logout",
+        "description": "Logout of the application",
+        "tags": [
+          "Auth Mgt"
+        ],
         "parameters": [
           {
             "name": "example-only",
@@ -612,16 +617,16 @@
           "200": {
             "description": "logout result"
           }
-        },
-        "summary": "Perform Logout",
-        "description": "Logout of the application",
-        "tags": [
-          "Auth Mgt"
-        ]
+        }
       }
     },
     "/user/list": {
       "get": {
+        "summary": "/user/list",
+        "description": "Return a user list",
+        "tags": [
+          "User List"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -633,16 +638,16 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "tags": [
-          "User List"
-        ],
-        "description": "Return a user list",
-        "summary": "/user/list"
+        }
       }
     },
     "/user/list2": {
       "get": {
+        "summary": "/user/list2",
+        "description": "Return a user list (alternate)",
+        "tags": [
+          "User List"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -654,16 +659,15 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "tags": [
-          "User List"
-        ],
-        "description": "Return a user list (alternate)",
-        "summary": "/user/list2"
+        }
       }
     },
     "/user/upload": {
       "get": {
+        "summary": "/user/upload",
+        "tags": [
+          "User"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -679,25 +683,21 @@
           "200": {
             "description": "Success"
           }
-        },
-        "summary": "/user/upload",
-        "tags": [
-          "User"
-        ]
+        }
       }
     },
     "/user/roles": {
       "put": {
+        "summary": "update user roles",
+        "tags": [
+          "User (Extra)"
+        ],
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
           }
         },
-        "summary": "update user roles",
-        "tags": [
-          "User (Extra)"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -721,6 +721,10 @@
     },
     "/nomodel/deep-url/more/find": {
       "get": {
+        "summary": "/nomodel/deep-url/more/find",
+        "tags": [
+          "No Model Example"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -732,15 +736,15 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "tags": [
-          "No Model Example"
-        ],
-        "summary": "/nomodel/deep-url/more/find"
+        }
       }
     },
     "/nomodel/deep-url/more/clear": {
       "get": {
+        "summary": "/nomodel/deep-url/more/clear",
+        "tags": [
+          "No Model Example"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -752,15 +756,16 @@
           "500": {
             "description": "Internal server error"
           }
-        },
-        "tags": [
-          "No Model Example"
-        ],
-        "summary": "/nomodel/deep-url/more/clear"
+        }
       }
     },
     "/user/test/{phoneNumber}": {
       "get": {
+        "summary": "Phone No. Logout",
+        "description": "Alternate description (of no real significance)",
+        "tags": [
+          "Auth Mgt"
+        ],
         "parameters": [
           {
             "name": "example-only",
@@ -795,12 +800,7 @@
             "description": "logout result"
           }
         },
-        "summary": "Phone No. Logout",
-        "description": "Alternate description (of no real significance)",
-        "operationId": "user/logout",
-        "tags": [
-          "Auth Mgt"
-        ]
+        "operationId": "user/logout"
       }
     },
     "/clients/{client_id}/user/{id}": {

--- a/test/fixtures/parsedRoutes.json
+++ b/test/fixtures/parsedRoutes.json
@@ -6,7 +6,270 @@
     "variables": [],
     "optionalVariables": [],
     "action": "user/create",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": false
+  },
+  {
+    "middlewareType": "ACTION",
+    "verb": "patch",
+    "path": "/user",
+    "variables": [],
+    "optionalVariables": [],
+    "action": "user/create",
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "ACTION",
@@ -43,6 +306,133 @@
     "optionalVariables": [],
     "action": "user/login",
     "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "login",
+    "isShortcutBlueprintRoute": false,
     "swagger": {
       "summary": "Authentication",
       "description": "This is for authentication of any user",
@@ -81,7 +471,134 @@
     "variables": [],
     "optionalVariables": [],
     "action": "user/logout",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "logout",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "ACTION",
@@ -90,7 +607,134 @@
     "variables": [],
     "optionalVariables": [],
     "action": "user/list",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "list",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "ACTION",
@@ -99,7 +743,134 @@
     "variables": [],
     "optionalVariables": [],
     "action": "user/list2",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "list2",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "ACTION",
@@ -109,6 +880,133 @@
     "optionalVariables": [],
     "action": "user/upload",
     "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "upload",
+    "isShortcutBlueprintRoute": false,
     "swagger": {
       "parameters": [
         {
@@ -136,6 +1034,133 @@
     "optionalVariables": [],
     "action": "user/roles",
     "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "roles",
+    "isShortcutBlueprintRoute": false,
     "swagger": {
       "summary": "update user roles",
       "tags": [
@@ -204,6 +1229,133 @@
     "optionalVariables": [],
     "action": "user/logout",
     "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "logout",
+    "isShortcutBlueprintRoute": false,
     "swagger": {
       "summary": "Phone No. Logout",
       "description": "Alternate description (of no real significance)",
@@ -220,7 +1372,134 @@
     ],
     "optionalVariables": [],
     "action": "user/destroy",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -228,8 +1507,8 @@
     "path": "/oldpet/find",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "shortcutBlueprint",
+    "action": "oldpet/find",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -310,7 +1589,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -320,8 +1601,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "shortcutBlueprint",
+    "action": "oldpet/findone",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -402,7 +1683,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -410,8 +1693,8 @@
     "path": "/oldpet/create",
     "variables": [],
     "optionalVariables": [],
-    "action": "create",
-    "actionType": "shortcutBlueprint",
+    "action": "oldpet/create",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -492,7 +1775,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -502,8 +1787,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "shortcutBlueprint",
+    "action": "oldpet/update",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -584,7 +1869,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -594,8 +1881,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "destroy",
-    "actionType": "shortcutBlueprint",
+    "action": "oldpet/destroy",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -676,7 +1963,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -684,8 +1973,8 @@
     "path": "/pet/find",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "shortcutBlueprint",
+    "action": "pet/find",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -762,7 +2051,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -772,8 +2063,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "shortcutBlueprint",
+    "action": "pet/findone",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -850,7 +2141,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -858,8 +2151,8 @@
     "path": "/pet/create",
     "variables": [],
     "optionalVariables": [],
-    "action": "create",
-    "actionType": "shortcutBlueprint",
+    "action": "pet/create",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -936,7 +2229,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -946,8 +2241,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "shortcutBlueprint",
+    "action": "pet/update",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -1024,7 +2319,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1034,8 +2331,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "destroy",
-    "actionType": "shortcutBlueprint",
+    "action": "pet/destroy",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -1112,7 +2409,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1120,8 +2419,8 @@
     "path": "/user/find",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "shortcutBlueprint",
+    "action": "user/find",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1246,7 +2545,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1256,8 +2557,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "shortcutBlueprint",
+    "action": "user/findone",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1382,7 +2683,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "ACTION",
@@ -1391,7 +2694,134 @@
     "variables": [],
     "optionalVariables": [],
     "action": "user/create",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1401,8 +2831,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "shortcutBlueprint",
+    "action": "user/update",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1527,7 +2957,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "ACTION",
@@ -1538,7 +2970,134 @@
     ],
     "optionalVariables": [],
     "action": "user/destroy",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1549,8 +3108,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "add",
-    "actionType": "shortcutBlueprint",
+    "action": "user/add",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1677,7 +3236,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "add",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1687,8 +3248,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "replace",
-    "actionType": "shortcutBlueprint",
+    "action": "user/replace",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1815,7 +3376,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "replace",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1826,8 +3389,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "remove",
-    "actionType": "shortcutBlueprint",
+    "action": "user/remove",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -1954,7 +3517,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "remove",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -1965,8 +3530,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "add",
-    "actionType": "shortcutBlueprint",
+    "action": "user/add",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -2093,7 +3658,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "add",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2103,8 +3670,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "replace",
-    "actionType": "shortcutBlueprint",
+    "action": "user/replace",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -2231,7 +3798,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "replace",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2242,8 +3811,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "remove",
-    "actionType": "shortcutBlueprint",
+    "action": "user/remove",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -2370,7 +3939,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "remove",
+    "isShortcutBlueprintRoute": true
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2378,8 +3949,8 @@
     "path": "/oldpet",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "blueprint",
+    "action": "oldpet/find",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2460,7 +4031,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2470,8 +4043,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "blueprint",
+    "action": "oldpet/findone",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2552,7 +4125,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2560,8 +4135,8 @@
     "path": "/oldpet",
     "variables": [],
     "optionalVariables": [],
-    "action": "create",
-    "actionType": "blueprint",
+    "action": "oldpet/create",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2642,7 +4217,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2652,8 +4229,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "oldpet/update",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2734,7 +4311,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2746,8 +4325,8 @@
     "optionalVariables": [
       "id"
     ],
-    "action": "destroy",
-    "actionType": "blueprint",
+    "action": "oldpet/destroy",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2828,7 +4407,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2838,8 +4419,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "oldpet/update",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -2920,7 +4501,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -2930,8 +4513,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "oldpet/populate",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -3014,7 +4597,9 @@
     },
     "associationAliases": [
       "owner"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3024,8 +4609,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "oldpet/populate",
+    "actionType": "function",
     "model": {
       "globalId": "OldPet",
       "primaryKey": "petID",
@@ -3108,7 +4693,9 @@
     },
     "associationAliases": [
       "caredForBy"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3116,8 +4703,8 @@
     "path": "/pet",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "blueprint",
+    "action": "pet/find",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3194,7 +4781,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3204,8 +4793,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "blueprint",
+    "action": "pet/findone",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3282,7 +4871,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3290,8 +4881,8 @@
     "path": "/pet",
     "variables": [],
     "optionalVariables": [],
-    "action": "create",
-    "actionType": "blueprint",
+    "action": "pet/create",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3368,7 +4959,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "create",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3378,8 +4971,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "pet/update",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3456,7 +5049,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3468,8 +5063,8 @@
     "optionalVariables": [
       "id"
     ],
-    "action": "destroy",
-    "actionType": "blueprint",
+    "action": "pet/destroy",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3546,7 +5141,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3556,8 +5153,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "pet/update",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3634,7 +5231,9 @@
       ],
       "swagger": {}
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3644,8 +5243,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "pet/populate",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3724,7 +5323,9 @@
     },
     "associationAliases": [
       "owner"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3734,8 +5335,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "pet/populate",
+    "actionType": "function",
     "model": {
       "globalId": "Pet",
       "primaryKey": "petID",
@@ -3814,7 +5415,9 @@
     },
     "associationAliases": [
       "caredForBy"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3822,8 +5425,8 @@
     "path": "/user",
     "variables": [],
     "optionalVariables": [],
-    "action": "find",
-    "actionType": "blueprint",
+    "action": "user/find",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -3948,7 +5551,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "find",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -3958,8 +5563,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "findone",
-    "actionType": "blueprint",
+    "action": "user/findone",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4084,7 +5689,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "findone",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4094,8 +5701,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "user/update",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4220,7 +5827,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "ACTION",
@@ -4233,7 +5842,134 @@
       "id"
     ],
     "action": "user/destroy",
-    "actionType": "function"
+    "actionType": "function",
+    "model": {
+      "globalId": "User",
+      "primaryKey": "id",
+      "identity": "user",
+      "attributes": {
+        "id": {
+          "type": "number",
+          "autoMigrations": {
+            "autoIncrement": true,
+            "unique": true,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "names": {
+          "type": "string",
+          "required": true,
+          "example": "First Middle Last",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          }
+        },
+        "email": {
+          "type": "string",
+          "description": "Just any old email",
+          "validations": {
+            "isEmail": true
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "sex": {
+          "type": "string",
+          "validations": {
+            "isIn": [
+              "Male",
+              "Female"
+            ]
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_string"
+          },
+          "required": false
+        },
+        "ageLimit": {
+          "type": "number",
+          "validations": {
+            "min": 15,
+            "max": 100
+          },
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_number"
+          },
+          "required": false
+        },
+        "pets": {
+          "collection": "pet",
+          "via": "owner",
+          "required": false
+        },
+        "favouritePet": {
+          "model": "pet",
+          "autoMigrations": {
+            "unique": false,
+            "autoIncrement": false,
+            "columnType": "_numberkey"
+          },
+          "required": false
+        },
+        "neighboursPets": {
+          "collection": "pet",
+          "via": "caredForBy",
+          "required": false
+        }
+      },
+      "associations": [
+        {
+          "alias": "pets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "owner"
+        },
+        {
+          "alias": "favouritePet",
+          "type": "model",
+          "model": "pet"
+        },
+        {
+          "alias": "neighboursPets",
+          "type": "collection",
+          "collection": "pet",
+          "via": "caredForBy"
+        }
+      ],
+      "swagger": {
+        "actions": {
+          "findone": {
+            "description": "_Alternate description_: Look up the **User** record with the specified ID."
+          }
+        },
+        "tags": [
+          {
+            "name": "User (ORM duplicate)",
+            "externalDocs": {
+              "url": "https://somewhere.com/alternate",
+              "description": "Refer to these alternate docs"
+            }
+          }
+        ],
+        "components": {
+          "parameters": []
+        }
+      }
+    },
+    "associationAliases": [],
+    "blueprintAction": "destroy",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4243,8 +5979,8 @@
       "id"
     ],
     "optionalVariables": [],
-    "action": "update",
-    "actionType": "blueprint",
+    "action": "user/update",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4369,7 +6105,9 @@
         }
       }
     },
-    "associationAliases": []
+    "associationAliases": [],
+    "blueprintAction": "update",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4380,8 +6118,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "add",
-    "actionType": "blueprint",
+    "action": "user/add",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4508,7 +6246,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "add",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4518,8 +6258,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "replace",
-    "actionType": "blueprint",
+    "action": "user/replace",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4646,7 +6386,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "replace",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4657,8 +6399,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "remove",
-    "actionType": "blueprint",
+    "action": "user/remove",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4785,7 +6527,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "remove",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4796,8 +6540,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "add",
-    "actionType": "blueprint",
+    "action": "user/add",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -4924,7 +6668,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "add",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -4934,8 +6680,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "replace",
-    "actionType": "blueprint",
+    "action": "user/replace",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -5062,7 +6808,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "replace",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -5073,8 +6821,8 @@
       "childid"
     ],
     "optionalVariables": [],
-    "action": "remove",
-    "actionType": "blueprint",
+    "action": "user/remove",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -5201,7 +6949,9 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "remove",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -5211,8 +6961,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "user/populate",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -5339,7 +7089,9 @@
     },
     "associationAliases": [
       "pets"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -5349,8 +7101,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "user/populate",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -5477,7 +7229,9 @@
     },
     "associationAliases": [
       "favouritePet"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   },
   {
     "middlewareType": "BLUEPRINT",
@@ -5487,8 +7241,8 @@
       "parentid"
     ],
     "optionalVariables": [],
-    "action": "populate",
-    "actionType": "blueprint",
+    "action": "user/populate",
+    "actionType": "function",
     "model": {
       "globalId": "User",
       "primaryKey": "id",
@@ -5615,6 +7369,8 @@
     },
     "associationAliases": [
       "neighboursPets"
-    ]
+    ],
+    "blueprintAction": "populate",
+    "isShortcutBlueprintRoute": false
   }
 ]

--- a/test/parsers.test.ts
+++ b/test/parsers.test.ts
@@ -201,7 +201,7 @@ describe ('Parsers', () => {
             expect(actual.map(r => r.path)).to.deep.equal(expectedPaths);
             expect(actual.every(route => {
               if(route.middlewareType === MiddlewareType.BLUEPRINT) {
-                return blueprintActions.includes(route.action as BluePrintAction);
+                return blueprintActions.includes(route.blueprintAction as BluePrintAction);
               } else {
                 return route.middlewareType === MiddlewareType.ACTION;
               }
@@ -213,7 +213,7 @@ describe ('Parsers', () => {
             const actual = parseBoundRoutes(boundRoutes as unknown as Sails.Route[], parsedModels, sails);
             const expectedPaths = [ '/user', '/user/:id', '/user/:id' ];
             expect(actual.filter(route => route.middlewareType == MiddlewareType.BLUEPRINT && !!route.model).map(r => r.path), 'should return model for all blueprint routes').to.deep.equal(expectedPaths);
-            const updateUserRoute = actual.find(route => route.action === 'update');
+            const updateUserRoute = actual.find(route => route.blueprintAction === 'update');
             expect(!!updateUserRoute?.model, 'should parse blueprint routes and auto add model to routes without model (based on action)').to.be.true;
         })
 

--- a/test/transformations.test.ts
+++ b/test/transformations.test.ts
@@ -70,6 +70,7 @@ describe('Transformations', () => {
 
       const expectedOutputPaths = [
         '/user',
+        '/user',
         '/actions2',
         '/twofind',
         '/twoclear',
@@ -83,7 +84,7 @@ describe('Transformations', () => {
         '/nomodel/deep-url/more/clear',
         '/nomodel/deep-url/more/should_be_excluded',
         '/user/test/{phoneNumber}',
-        '/clients/{client_id}/user/{id}',
+        '/clients/{client_id}/user/{_id}',
         '/oldpet/find',
         '/oldpet/find/{_petID}',
         '/oldpet/create',
@@ -98,7 +99,7 @@ describe('Transformations', () => {
         '/user/find/{_id}',
         '/user/create',
         '/user/update/{_id}',
-        '/user/destroy/{id}',
+        '/user/destroy/{_id}',
         '/user/{_id}/{association}/add/{childid}',
         '/user/{_id}/{association}/replace',
         '/user/{_id}/{association}/remove/{childid}',
@@ -119,7 +120,7 @@ describe('Transformations', () => {
         '/user',
         '/user/{_id}',
         '/user/{_id}',
-        '/user/{id}', // note UserController overrides destroy action
+        '/user/{_id}',
         '/user/{_id}',
         '/user/{_id}/{association}/{childid}',
         '/user/{_id}/{association}',

--- a/types/sails.d.ts
+++ b/types/sails.d.ts
@@ -118,7 +118,7 @@ declare namespace Sails {
     export interface AttributeDefinition {
 
       // basic semantics
-      type: AttributeType;
+      type?: AttributeType;
       required?: boolean;
       defaultsTo?: any;
       allowNull?: boolean;


### PR DESCRIPTION
### Overview

Ensure all `{modelIdentity}/{action}` actions are handled as 'model-related':

1. All `{modelIdentity}/{action}` actions treated as related to the model (including `/allActions`) and Swagger content integrated / merged appropriately.
2. Actions2 actions recognised as model-related, and therefore recognised as blueprint action overrides (where applicable)
3. Improve consistency of handling/merging of actions (and Swagger documentation) relating to model controllers.

### Details

- refactor: Improve `SwaggerRouteInfo` interface

    Improve `SwaggerRouteInfo` interface to support above:
    1. Add separate fields for action vs blueprint action.
    2. Add separate flag for shortcut blueprint routes.

- refactor: Refactor route parsing using `{modelIdentity}/{action}`
    
    Refactor route parsing to rely predominantly on `{modelIdentity}/{action}` to ensure all model-related actions (including overrides including actions2) are captured. This is consistent with Sails `parseBlueprintOptions()`.

- refactor: Refactor transformations phase for `SwaggerRouteInfo` changes

- refactor: Refactor Swagger generation for model-related changes

    Refactor generation to improve route/model/controller Swagger merge.
    
    Refactor for `SwaggerRouteInfo` changes. 

- test: Refactor tests for Swagger generation (model-related changes)

    Swagger generation  changes related to new test cases and model-related merge changes (UserController now equivalent to User model).    

    Swagger generation merge changes resulted in ordering changes in generated output.
    
    Add new Actions2 action overriding blueprint action.
    
    Adjust `UserController` to add new Swagger merge.
    
    Includes full re-generation of parsed routes based on `SwaggerRouteInfo` changes.
    
    Minor adjustment to Sails AttributeDefinition as `type` optional.

